### PR TITLE
에러 응답 형식 추가

### DIFF
--- a/backend/src/main/java/zipgo/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/zipgo/controller/GlobalExceptionHandler.java
@@ -39,7 +39,8 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         if (isAlreadyCommitted(request)) {
             return null;
         }
-        return ResponseEntity.status(statusCode).body(ErrorResponse.of(ex));
+        return ResponseEntity.status(statusCode)
+                .body(ErrorResponse.of(ex));
     }
 
     private boolean isAlreadyCommitted(WebRequest request) {

--- a/backend/src/main/java/zipgo/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/zipgo/controller/GlobalExceptionHandler.java
@@ -1,19 +1,48 @@
 package zipgo.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import zipgo.controller.dto.ErrorResponse;
 import zipgo.exception.KeywordException;
 
 @RestControllerAdvice
+@Log4j2
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler({KeywordException.NotFound.class})
     public ResponseEntity<ErrorResponse> handleNotFoundException(Exception exception) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(ErrorResponse.of(exception));
+    }
+
+    @ExceptionHandler({Exception.class})
+    public ResponseEntity<ErrorResponse> handleException(Exception exception) {
+        logger.error("서버 내부 오류 발생", exception);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse("서버 내부 오류"));
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body,
+                                                             HttpHeaders headers,
+                                                             HttpStatusCode statusCode,
+                                                             WebRequest request) {
+        if (request instanceof ServletWebRequest servletWebRequest) {
+            HttpServletResponse response = servletWebRequest.getResponse();
+            if (response != null && response.isCommitted()) {
+                return null;
+            }
+        }
+        return ResponseEntity.status(statusCode).body(ErrorResponse.of(ex));
     }
 
 }

--- a/backend/src/main/java/zipgo/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/zipgo/controller/GlobalExceptionHandler.java
@@ -11,8 +11,9 @@ import zipgo.exception.KeywordException;
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler({KeywordException.NotFound.class})
-    public ResponseEntity<String> handleNotFoundException(Exception exception) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
+    public ResponseEntity<ErrorResponse> handleNotFoundException(Exception exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.of(exception));
     }
 
 }

--- a/backend/src/main/java/zipgo/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/zipgo/controller/GlobalExceptionHandler.java
@@ -36,13 +36,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                                                              HttpHeaders headers,
                                                              HttpStatusCode statusCode,
                                                              WebRequest request) {
-        if (request instanceof ServletWebRequest servletWebRequest) {
-            HttpServletResponse response = servletWebRequest.getResponse();
-            if (response != null && response.isCommitted()) {
-                return null;
-            }
+        if (isAlreadyCommitted(request)) {
+            return null;
         }
         return ResponseEntity.status(statusCode).body(ErrorResponse.of(ex));
+    }
+
+    private boolean isAlreadyCommitted(WebRequest request) {
+        ServletWebRequest servletWebRequest = (ServletWebRequest) request;
+        HttpServletResponse response = servletWebRequest.getResponse();
+        return response != null && response.isCommitted();
     }
 
 }

--- a/backend/src/main/java/zipgo/controller/dto/ErrorResponse.java
+++ b/backend/src/main/java/zipgo/controller/dto/ErrorResponse.java
@@ -1,0 +1,11 @@
+package zipgo.controller.dto;
+
+public record ErrorResponse(
+        String message
+) {
+
+    public static ErrorResponse of(Exception exception) {
+        return new ErrorResponse(exception.getMessage());
+    }
+
+}

--- a/backend/src/main/java/zipgo/exception/KeywordException.java
+++ b/backend/src/main/java/zipgo/exception/KeywordException.java
@@ -9,7 +9,7 @@ public class KeywordException extends RuntimeException {
     public static class NotFound extends KeywordException {
 
         public NotFound(String keywordName) {
-            super(String.format("이름이 $s 인 키워드를 찾을 수 없습니다.", keywordName));
+            super(String.format("이름이 %s 인 키워드를 찾을 수 없습니다.", keywordName));
         }
 
     }

--- a/backend/src/test/java/zipgo/acceptance/PetFoodAcceptanceTest.java
+++ b/backend/src/test/java/zipgo/acceptance/PetFoodAcceptanceTest.java
@@ -7,6 +7,7 @@ import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
+import zipgo.controller.dto.ErrorResponse;
 import zipgo.controller.dto.GetPetFoodsResponse;
 
 public class PetFoodAcceptanceTest extends AcceptanceTest {
@@ -43,7 +44,10 @@ public class PetFoodAcceptanceTest extends AcceptanceTest {
                 .when().get("/pet-foods")
                 .then().extract();
 
+        ErrorResponse data = response.body().as(ErrorResponse.class);
+
         assertThat(response.statusCode()).isEqualTo(404);
+        assertThat(data.message()).isEqualTo("이름이 존재하지 않는 키워드 인 키워드를 찾을 수 없습니다.");
     }
 
 }

--- a/backend/src/test/java/zipgo/controller/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/zipgo/controller/GlobalExceptionHandlerTest.java
@@ -1,0 +1,59 @@
+package zipgo.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import zipgo.acceptance.AcceptanceTest;
+import zipgo.controller.dto.ErrorResponse;
+
+class GlobalExceptionHandlerTest extends AcceptanceTest {
+
+    @SpyBean(name = "petFoodController")
+    private PetFoodController petFoodController;
+
+    class TestException extends RuntimeException {
+
+        TestException() {
+            super("테스트 예외입니다.");
+        }
+
+    }
+
+    @Test
+    void 서버_내부_에러가_발생하면_500을_반환한다() {
+        //given
+        given(petFoodController.getPetFoods(any())).willThrow(TestException.class);
+
+        //when
+        var response = RestAssured
+                .when().get("/pet-foods")
+                .then().extract();
+
+        //then
+        var errorResponse = response.as(ErrorResponse.class);
+        assertThat(errorResponse.message()).isEqualTo("서버 내부 오류");
+    }
+
+    @Test
+    void 스프링_예외가_발생했을때_에러_응답_형식을_반환한다() {
+        //given
+        given(petFoodController.getPetFoods(any())).willAnswer((a) -> {
+            throw new HttpMediaTypeNotSupportedException("스프링 예외 메시지");
+        });
+
+        //when
+        var response = RestAssured
+                .when().get("/pet-foods")
+                .then().extract();
+
+        //then
+        var errorResponse = response.as(ErrorResponse.class);
+        assertThat(errorResponse.message()).isEqualTo("스프링 예외 메시지");
+    }
+
+}

--- a/backend/src/test/java/zipgo/controller/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/zipgo/controller/GlobalExceptionHandlerTest.java
@@ -5,6 +5,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
@@ -16,26 +18,18 @@ class GlobalExceptionHandlerTest extends AcceptanceTest {
     @SpyBean(name = "petFoodController")
     private PetFoodController petFoodController;
 
-    class TestException extends RuntimeException {
-
-        TestException() {
-            super("테스트 예외입니다.");
-        }
-
-    }
-
     @Test
     void 서버_내부_에러가_발생하면_500을_반환한다() {
         //given
         given(petFoodController.getPetFoods(any())).willThrow(TestException.class);
 
         //when
-        var response = RestAssured
+        ExtractableResponse<Response> response = RestAssured
                 .when().get("/pet-foods")
                 .then().extract();
 
         //then
-        var errorResponse = response.as(ErrorResponse.class);
+        ErrorResponse errorResponse = response.as(ErrorResponse.class);
         assertThat(errorResponse.message()).isEqualTo("서버 내부 오류");
     }
 
@@ -47,13 +41,21 @@ class GlobalExceptionHandlerTest extends AcceptanceTest {
         });
 
         //when
-        var response = RestAssured
+        ExtractableResponse<Response> response = RestAssured
                 .when().get("/pet-foods")
                 .then().extract();
 
         //then
-        var errorResponse = response.as(ErrorResponse.class);
+        ErrorResponse errorResponse = response.as(ErrorResponse.class);
         assertThat(errorResponse.message()).isEqualTo("스프링 예외 메시지");
+    }
+
+    class TestException extends RuntimeException {
+
+        TestException() {
+            super("테스트 예외입니다.");
+        }
+
     }
 
 }


### PR DESCRIPTION
## 📄 Summary
> 예외 응답에 형식이 생겼습니다.

- 원래는 ResponseEntity로 바디에 데이터를 바로 넣어주기로 했었는데, 논의 후 에러에 응답 형식을 추가하기로 결정했습니다.
- 그리고 Exception을 잡는 핸들러에 형식을 적용했습니다

- closes: #27 

## 🙋🏻 More
> 유의사항..

엔드포인트가 존재하지 않을 때는 예외가 발생하지 않고 NoHandlerFoundException은 따로 설정해줘야 발생합니다
따로 설정을 해줘야합니다 설정 방법: https://tecoble.techcourse.co.kr/post/2021-11-24-spring-customize-unhandled-api/

근데 제가 .. 쇼핑 미션때 경험한 바로는 정적 파일을 관리하는 입장에서 저걸 적용하는게 좀 귀찮았어요. 글처럼 쉽게 안됐었거든요
생각을 해보면
경로가 없어서 나는 예외를 만난 클라이언트가 바디까지 열어볼 필요가 있나? 그리고 있다고 해도 원래의 응답으로도 디버깅이 가능해요.
그래서 NoHandlerFoundException의 404 응답은 처리를 해주지 않아도 될것같아 적용하지 않고 PR 생성합니다