### PR TITLE
백엔드 코드 커버리지 설정(with Jacoco)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -12,6 +12,10 @@ java {
     sourceCompatibility = '17'
 }
 
+jacoco {
+    toolVersion = "0.8.8"
+}
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
@@ -42,18 +46,10 @@ tasks.named('test') {
     finalizedBy 'jacocoTestReport'
 }
 
-jacoco {
-    toolVersion = "0.8.7"
-}
-
 jacocoTestReport {
     reports {
-        xml.enabled true
-        csv.enabled true
-        html.enabled true
+        html.required = true
 
-        xml.destination file("${buildDir}/jacoco/index.xml")
-        csv.destination file("${buildDir}/jacoco/index.csv")
         html.destination file("${buildDir}/jacoco/index.html")
     }
 
@@ -88,8 +84,8 @@ jacocoTestCoverageVerification {
             excludes = [
                     '*.*Application',
                     '*.*Exception',
-                    '*.Response.*',
-                    '*.Request.*'
+                    '*.*Response',
+                    '*.*Request'
             ]
         }
     }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.1'
     id 'io.spring.dependency-management' version '1.1.0'
+    id 'jacoco'
 }
 
 group = 'zipgo'
@@ -38,4 +39,58 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+}
+
+jacoco {
+    toolVersion = "0.8.7"
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+        csv.enabled true
+        html.enabled true
+
+        xml.destination file("${buildDir}/jacoco/index.xml")
+        csv.destination file("${buildDir}/jacoco/index.csv")
+        html.destination file("${buildDir}/jacoco/index.html")
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, excludes: [
+                            '**/*Application*',
+                            '**/*Exception*',
+                            '**/*Response*',
+                            '**/*Request*'
+                    ])
+                })
+        )
+    }
+
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = "CLASS"
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.9
+            }
+
+            excludes = [
+                    '*.*Application',
+                    '*.*Exception',
+                    '*.Response.*',
+                    '*.Request.*'
+            ]
+        }
+    }
 }


### PR DESCRIPTION
## 📄 Summary
> 백엔드 코드 커버리지가 90퍼가 넘어가지 않으면 빌드가 실패하도록 설정
#28 

## 🙋🏻 More
> 
테스트 실행 후 각 클래스 별 파일을 html 파일 형태로 시각화하여 볼 수 있도록 설정
경로 -> build/jacoco/index.html/index.html

- ZipgoApplication(*Application)
- 예외 (*Exception)
- DTO( *Request, *Response )
는 커버리지 계산에서 제외하도록 설정하였습니다~!

커버리지가 기준점(현 설정값 0.9)를 넘지 못하면 테스트시 아래처럼 빌드 실패합니다
<img width="1259" alt="image" src="https://github.com/woowacourse-teams/2023-zipgo/assets/73161212/f9de550d-f3b8-44cd-947b-1eff03a704b2">