### PR TITLE
식품 목록 조회 API 응답 형식 수정

### DIFF
--- a/backend/src/main/java/zipgo/controller/dto/GetPetFoodsResponse.java
+++ b/backend/src/main/java/zipgo/controller/dto/GetPetFoodsResponse.java
@@ -1,9 +1,10 @@
 package zipgo.controller.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import zipgo.domain.PetFood;
 
-public record GetPetFoodsResponse(List<PetFoodResponse> petFoods) {
+public record GetPetFoodsResponse(@JsonProperty(value = "foodList") List<PetFoodResponse> petFoods) {
 
     public static GetPetFoodsResponse from(List<PetFood> petFoods) {
         List<PetFoodResponse> petFoodResponses = petFoods.stream()

--- a/backend/src/test/java/zipgo/acceptance/PetFoodAcceptanceTest.java
+++ b/backend/src/test/java/zipgo/acceptance/PetFoodAcceptanceTest.java
@@ -6,8 +6,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import zipgo.controller.dto.GetPetFoodsResponse;
+import zipgo.controller.dto.PetFoodResponse;
 
 public class PetFoodAcceptanceTest extends AcceptanceTest {
 
@@ -21,6 +23,19 @@ public class PetFoodAcceptanceTest extends AcceptanceTest {
 
         assertThat(response.statusCode()).isEqualTo(200);
         assertThat(data.petFoods()).isNotEmpty();
+    }
+
+    @Test
+    void petFoods를_foodList로_직렬화한다() {
+        //given
+        ExtractableResponse<Response> response = given().contentType(ContentType.JSON)
+                .when().get("/pet-foods")
+                .then().extract();
+
+        //when
+        //then
+        List<PetFoodResponse> foodList = response.jsonPath().getList("foodList", PetFoodResponse.class);
+        assertThat(foodList).isNotEmpty();
     }
 
     @Test


### PR DESCRIPTION
## 📄 Summary
> 응답 형식 수정했어요

petFoods 리스트의 프로퍼티명을 foodList로 직렬화합니다

- closes: #31

```json
{
    "foodList": [
        {
            "id": 1,
            "imageUrl": "https://avatars.githubusercontent.com/u/94087228?v=4",
            "name": "[고집] 돌아온 배배",
            "purchaseUrl": "https://github.com/woowacourse-teams/2023-zipgo"
        },
        {
            "id": 2,
            "imageUrl": "https://avatars.githubusercontent.com/u/76938931?v=4",
            "name": "[고집] 갈비 맛 모밀",
            "purchaseUrl": "https://github.com/woowacourse-teams/2023-zipgo"
        }
    ]
}
```

## 🙋🏻 More

테스트 했어여
