### PR TITLE
refactor: 식품 상세 조회를 조회 서비스로 분리

### DIFF
--- a/backend/src/main/java/zipgo/auth/application/KakaoOAuthClient.java
+++ b/backend/src/main/java/zipgo/auth/application/KakaoOAuthClient.java
@@ -1,8 +1,5 @@
 package zipgo.auth.application;
 
-import static org.springframework.http.HttpMethod.GET;
-import static org.springframework.http.HttpMethod.POST;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -18,6 +15,9 @@ import zipgo.auth.application.dto.KakaoMemberResponse;
 import zipgo.auth.application.dto.KakaoTokenResponse;
 import zipgo.auth.application.dto.OAuthMemberResponse;
 import zipgo.auth.exception.AuthException;
+
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
 
 @Component
 @RequiredArgsConstructor

--- a/backend/src/main/java/zipgo/auth/presentation/BearerTokenExtractor.java
+++ b/backend/src/main/java/zipgo/auth/presentation/BearerTokenExtractor.java
@@ -1,9 +1,9 @@
 package zipgo.auth.presentation;
 
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-
 import jakarta.servlet.http.HttpServletRequest;
 import zipgo.auth.exception.AuthException;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 public class BearerTokenExtractor {
 

--- a/backend/src/main/java/zipgo/auth/util/JwtProvider.java
+++ b/backend/src/main/java/zipgo/auth/util/JwtProvider.java
@@ -1,9 +1,6 @@
 package zipgo.auth.util;
 
 
-import static io.jsonwebtoken.security.Keys.hmacShaKeyFor;
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
@@ -16,6 +13,9 @@ import javax.crypto.SecretKey;
 import org.springframework.stereotype.Component;
 import zipgo.auth.exception.AuthException;
 import zipgo.common.config.JwtCredentials;
+
+import static io.jsonwebtoken.security.Keys.hmacShaKeyFor;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 @Component
 public class JwtProvider {

--- a/backend/src/main/java/zipgo/brand/domain/Brand.java
+++ b/backend/src/main/java/zipgo/brand/domain/Brand.java
@@ -1,8 +1,5 @@
 package zipgo.brand.domain;
 
-import static jakarta.persistence.GenerationType.IDENTITY;
-import static lombok.AccessLevel.PROTECTED;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -16,6 +13,9 @@ import lombok.EqualsAndHashCode.Include;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import zipgo.petfood.domain.PetFood;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @Entity

--- a/backend/src/main/java/zipgo/common/GlobalExceptionHandler.java
+++ b/backend/src/main/java/zipgo/common/GlobalExceptionHandler.java
@@ -1,9 +1,5 @@
 package zipgo.common;
 
-import static org.springframework.http.HttpStatus.FORBIDDEN;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
-
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpHeaders;
@@ -19,6 +15,10 @@ import zipgo.member.exception.MemberException;
 import zipgo.petfood.exception.PetFoodException;
 import zipgo.petfood.presentation.dto.ErrorResponse;
 import zipgo.review.exception.ReviewException;
+
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Log4j2
 @RestControllerAdvice

--- a/backend/src/main/java/zipgo/common/config/WebConfig.java
+++ b/backend/src/main/java/zipgo/common/config/WebConfig.java
@@ -1,5 +1,6 @@
 package zipgo.common.config;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -9,8 +10,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import zipgo.auth.presentation.AuthInterceptor;
 import zipgo.auth.presentation.JwtArgumentResolver;
 import zipgo.auth.util.JwtProvider;
-
-import java.util.List;
 
 import static org.springframework.http.HttpHeaders.LOCATION;
 

--- a/backend/src/main/java/zipgo/member/domain/Member.java
+++ b/backend/src/main/java/zipgo/member/domain/Member.java
@@ -1,8 +1,5 @@
 package zipgo.member.domain;
 
-import static lombok.AccessLevel.PROTECTED;
-import static lombok.EqualsAndHashCode.Include;
-
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -12,6 +9,9 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+import static lombok.EqualsAndHashCode.Include;
 
 @Entity
 @Getter

--- a/backend/src/main/java/zipgo/petfood/application/PetFoodQueryService.java
+++ b/backend/src/main/java/zipgo/petfood/application/PetFoodQueryService.java
@@ -1,7 +1,5 @@
 package zipgo.petfood.application;
 
-import static java.util.Arrays.asList;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -15,6 +13,9 @@ import zipgo.petfood.domain.PetFood;
 import zipgo.petfood.domain.repository.PetFoodQueryRepository;
 import zipgo.petfood.domain.repository.PetFoodRepository;
 import zipgo.petfood.presentation.dto.FilterResponse;
+import zipgo.petfood.presentation.dto.GetPetFoodResponse;
+
+import static java.util.Arrays.asList;
 
 @Service
 @RequiredArgsConstructor
@@ -102,6 +103,12 @@ public class PetFoodQueryService {
                 .toList();
 
         return FilterResponse.from(brands, primaryIngredients, functionalities);
+    }
+
+    public GetPetFoodResponse getPetFoodResponse(Long id) {
+        PetFood petfood = petFoodRepository.getById(id);
+
+        return GetPetFoodResponse.of(petfood, petfood.calculateRatingAverage(), petfood.countReviews());
     }
 
 }

--- a/backend/src/main/java/zipgo/petfood/application/PetFoodQueryService.java
+++ b/backend/src/main/java/zipgo/petfood/application/PetFoodQueryService.java
@@ -83,10 +83,6 @@ public class PetFoodQueryService {
         return petFoodQueryRepository.findPetFoods(keyword, brand, primaryIngredients);
     }
 
-    public PetFood getPetFoodBy(Long id) {
-        return petFoodRepository.getById(id);
-    }
-
     public FilterResponse getMetadataForFilter() {
         List<Brand> brands = brandRepository.findAll();
 

--- a/backend/src/main/java/zipgo/petfood/domain/Keyword.java
+++ b/backend/src/main/java/zipgo/petfood/domain/Keyword.java
@@ -1,8 +1,5 @@
 package zipgo.petfood.domain;
 
-import static jakarta.persistence.GenerationType.IDENTITY;
-import static lombok.AccessLevel.PROTECTED;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -13,6 +10,9 @@ import lombok.EqualsAndHashCode;
 import lombok.EqualsAndHashCode.Include;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter

--- a/backend/src/main/java/zipgo/petfood/domain/PetFood.java
+++ b/backend/src/main/java/zipgo/petfood/domain/PetFood.java
@@ -1,7 +1,5 @@
 package zipgo.petfood.domain;
 
-import static jakarta.persistence.FetchType.LAZY;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -19,6 +17,8 @@ import lombok.EqualsAndHashCode.Include;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import zipgo.brand.domain.Brand;
+
+import static jakarta.persistence.FetchType.LAZY;
 
 @Entity
 @Getter

--- a/backend/src/main/java/zipgo/petfood/domain/repository/PetFoodQueryRepository.java
+++ b/backend/src/main/java/zipgo/petfood/domain/repository/PetFoodQueryRepository.java
@@ -1,10 +1,5 @@
 package zipgo.petfood.domain.repository;
 
-import static org.springframework.util.StringUtils.hasText;
-import static zipgo.brand.domain.QBrand.brand;
-import static zipgo.petfood.domain.QKeyword.keyword;
-import static zipgo.petfood.domain.QPetFood.petFood;
-
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -13,6 +8,11 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import zipgo.petfood.domain.PetFood;
 import zipgo.petfood.domain.PrimaryIngredients;
+
+import static org.springframework.util.StringUtils.hasText;
+import static zipgo.brand.domain.QBrand.brand;
+import static zipgo.petfood.domain.QKeyword.keyword;
+import static zipgo.petfood.domain.QPetFood.petFood;
 
 @Repository
 @RequiredArgsConstructor

--- a/backend/src/main/java/zipgo/petfood/presentation/PetFoodController.java
+++ b/backend/src/main/java/zipgo/petfood/presentation/PetFoodController.java
@@ -1,8 +1,5 @@
 package zipgo.petfood.presentation;
 
-import static java.net.URLDecoder.decode;
-import static java.util.Collections.EMPTY_LIST;
-
 import io.jsonwebtoken.lang.Strings;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
@@ -21,6 +18,9 @@ import zipgo.petfood.presentation.dto.FilterMetadataResponse;
 import zipgo.petfood.presentation.dto.FilterResponse;
 import zipgo.petfood.presentation.dto.GetPetFoodResponse;
 import zipgo.petfood.presentation.dto.GetPetFoodsResponse;
+
+import static java.net.URLDecoder.decode;
+import static java.util.Collections.EMPTY_LIST;
 
 @RestController
 @RequiredArgsConstructor
@@ -55,10 +55,8 @@ public class PetFoodController {
 
     @GetMapping("/{id}")
     public ResponseEntity<GetPetFoodResponse> getPetFood(@PathVariable Long id) {
-        PetFood foundPetFood = petFoodQueryService.getPetFoodBy(id);
-        int reviewCount = foundPetFood.countReviews();
-        double ratingAverage = foundPetFood.calculateRatingAverage();
-        return ResponseEntity.ok(GetPetFoodResponse.of(foundPetFood, ratingAverage, reviewCount));
+        GetPetFoodResponse petFoodResponse = petFoodQueryService.getPetFoodResponse(id);
+        return ResponseEntity.ok(petFoodResponse);
     }
 
     @GetMapping("/filters")

--- a/backend/src/main/java/zipgo/petfood/presentation/dto/GetPetFoodResponse.java
+++ b/backend/src/main/java/zipgo/petfood/presentation/dto/GetPetFoodResponse.java
@@ -51,7 +51,8 @@ public record GetPetFoodResponse(
     public record PetFoodBrandResponse(
             String name,
             String imageUrl,
-            String state,
+            @JsonProperty("state")
+            String nation,
             int foundedYear,
             boolean hasResearchCenter,
             boolean hasResidentVet

--- a/backend/src/main/java/zipgo/review/domain/AdverseReaction.java
+++ b/backend/src/main/java/zipgo/review/domain/AdverseReaction.java
@@ -1,10 +1,5 @@
 package zipgo.review.domain;
 
-import static jakarta.persistence.EnumType.STRING;
-import static jakarta.persistence.FetchType.LAZY;
-import static lombok.AccessLevel.PROTECTED;
-import static lombok.EqualsAndHashCode.Include;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
@@ -18,6 +13,11 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import zipgo.review.domain.type.AdverseReactionType;
+
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+import static lombok.EqualsAndHashCode.Include;
 
 @Entity
 @Getter

--- a/backend/src/main/java/zipgo/review/domain/Review.java
+++ b/backend/src/main/java/zipgo/review/domain/Review.java
@@ -1,11 +1,5 @@
 package zipgo.review.domain;
 
-import static jakarta.persistence.CascadeType.PERSIST;
-import static jakarta.persistence.CascadeType.REMOVE;
-import static jakarta.persistence.EnumType.STRING;
-import static jakarta.persistence.FetchType.LAZY;
-import static lombok.AccessLevel.PROTECTED;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Enumerated;
@@ -31,6 +25,12 @@ import zipgo.petfood.domain.PetFood;
 import zipgo.review.domain.type.AdverseReactionType;
 import zipgo.review.domain.type.StoolCondition;
 import zipgo.review.domain.type.TastePreference;
+
+import static jakarta.persistence.CascadeType.PERSIST;
+import static jakarta.persistence.CascadeType.REMOVE;
+import static jakarta.persistence.EnumType.STRING;
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter

--- a/backend/src/main/java/zipgo/review/dto/response/GetReviewsResponse.java
+++ b/backend/src/main/java/zipgo/review/dto/response/GetReviewsResponse.java
@@ -1,9 +1,9 @@
 package zipgo.review.dto.response;
 
-import static java.time.format.DateTimeFormatter.ofPattern;
-
 import java.util.List;
 import zipgo.review.domain.Review;
+
+import static java.time.format.DateTimeFormatter.ofPattern;
 
 public record GetReviewsResponse(
         Long id,

--- a/backend/src/test/java/zipgo/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/zipgo/acceptance/AcceptanceTest.java
@@ -1,9 +1,5 @@
 package zipgo.acceptance;
 
-import static com.epages.restdocs.apispec.Schema.schema;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
-
 import com.epages.restdocs.apispec.Schema;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
@@ -20,6 +16,10 @@ import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import zipgo.auth.util.JwtProvider;
+
+import static com.epages.restdocs.apispec.Schema.schema;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.documentationConfiguration;
 
 @SuppressWarnings("NonAsciiCharacters")
 @Sql(scripts = {"classpath:truncate.sql", "classpath:data.sql"})

--- a/backend/src/test/java/zipgo/acceptance/PetFoodAcceptanceTest.java
+++ b/backend/src/test/java/zipgo/acceptance/PetFoodAcceptanceTest.java
@@ -1,11 +1,19 @@
 package zipgo.acceptance;
 
+import com.epages.restdocs.apispec.ResourceSnippetDetails;
+import com.epages.restdocs.apispec.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.restassured.RestDocumentationFilter;
+import org.springframework.test.context.jdbc.Sql;
+
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.resourceDetails;
 import static com.epages.restdocs.apispec.Schema.schema;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static java.util.Collections.EMPTY_LIST;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
@@ -17,16 +25,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-
-import com.epages.restdocs.apispec.ResourceSnippetDetails;
-import com.epages.restdocs.apispec.Schema;
-import java.util.List;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.restdocs.restassured.RestDocumentationFilter;
-import org.springframework.test.context.jdbc.Sql;
 
 public class PetFoodAcceptanceTest extends AcceptanceTest {
 

--- a/backend/src/test/java/zipgo/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/zipgo/auth/application/AuthServiceTest.java
@@ -1,12 +1,6 @@
 package zipgo.auth.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
-import static zipgo.member.domain.fixture.MemberFixture.식별자_없는_멤버;
-import static zipgo.member.domain.fixture.MemberFixture.식별자_있는_멤버;
-
 import java.util.Optional;
-
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -17,6 +11,11 @@ import zipgo.auth.application.dto.KakaoMemberResponse;
 import zipgo.auth.util.JwtProvider;
 import zipgo.member.domain.Member;
 import zipgo.member.domain.repository.MemberRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static zipgo.member.domain.fixture.MemberFixture.식별자_없는_멤버;
+import static zipgo.member.domain.fixture.MemberFixture.식별자_있는_멤버;
 
 @SpringBootTest
 @SuppressWarnings("NonAsciiCharacters")

--- a/backend/src/test/java/zipgo/auth/application/KakaoOAuthClientTest.java
+++ b/backend/src/test/java/zipgo/auth/application/KakaoOAuthClientTest.java
@@ -1,13 +1,5 @@
 package zipgo.auth.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
-import static org.springframework.http.HttpMethod.GET;
-import static org.springframework.http.HttpMethod.POST;
-import static zipgo.auth.application.KakaoOAuthClient.KAKAO_ACCESS_TOKEN_URI;
-import static zipgo.auth.application.KakaoOAuthClient.KAKAO_USER_INFO_URI;
-
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
@@ -26,6 +18,14 @@ import zipgo.auth.application.dto.KakaoMemberResponse;
 import zipgo.auth.application.dto.KakaoTokenResponse;
 import zipgo.auth.application.dto.OAuthMemberResponse;
 import zipgo.auth.exception.AuthException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+import static zipgo.auth.application.KakaoOAuthClient.KAKAO_ACCESS_TOKEN_URI;
+import static zipgo.auth.application.KakaoOAuthClient.KAKAO_USER_INFO_URI;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -72,6 +72,7 @@ class KakaoOAuthClientTest {
             // then
             assertThat(oAuthMemberResponse).isNotNull();
         }
+
     }
 
     @Nested

--- a/backend/src/test/java/zipgo/auth/presentation/AuthControllerMockArgumentResolverTest.java
+++ b/backend/src/test/java/zipgo/auth/presentation/AuthControllerMockArgumentResolverTest.java
@@ -1,19 +1,5 @@
 package zipgo.auth.presentation;
 
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.resourceDetails;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static zipgo.member.domain.fixture.MemberFixture.식별자_있는_멤버;
-
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.Schema;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +19,20 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolver;
 import zipgo.auth.presentation.dto.AuthDto;
 import zipgo.member.application.MemberQueryService;
+
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.resourceDetails;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static zipgo.member.domain.fixture.MemberFixture.식별자_있는_멤버;
 
 
 @SuppressWarnings("NonAsciiCharacters")

--- a/backend/src/test/java/zipgo/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/zipgo/auth/presentation/AuthControllerTest.java
@@ -1,15 +1,5 @@
 package zipgo.auth.presentation;
 
-import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.resourceDetails;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static zipgo.member.domain.fixture.MemberFixture.식별자_있는_멤버;
-
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.Schema;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -27,6 +17,16 @@ import org.springframework.test.web.servlet.MockMvc;
 import zipgo.auth.application.AuthService;
 import zipgo.auth.util.JwtProvider;
 import zipgo.member.application.MemberQueryService;
+
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.resourceDetails;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static zipgo.member.domain.fixture.MemberFixture.식별자_있는_멤버;
 
 @AutoConfigureRestDocs
 @ExtendWith(SpringExtension.class)
@@ -60,7 +60,7 @@ class AuthControllerTest {
 
         // when
         var 요청 = mockMvc.perform(post("/auth/login")
-                .param("code", "인가_코드"))
+                        .param("code", "인가_코드"))
                 .andDo(소셜_로그인_문서_생성());
 
         // then

--- a/backend/src/test/java/zipgo/auth/presentation/BearerTokenExtractorTest.java
+++ b/backend/src/test/java/zipgo/auth/presentation/BearerTokenExtractorTest.java
@@ -1,13 +1,13 @@
 package zipgo.auth.presentation;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import zipgo.auth.exception.AuthException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)

--- a/backend/src/test/java/zipgo/auth/util/JwtProviderTest.java
+++ b/backend/src/test/java/zipgo/auth/util/JwtProviderTest.java
@@ -1,12 +1,5 @@
 package zipgo.auth.util;
 
-import static io.jsonwebtoken.SignatureAlgorithm.HS256;
-import static io.jsonwebtoken.security.Keys.hmacShaKeyFor;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-
 import io.jsonwebtoken.Jwts;
 import java.util.Date;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -16,6 +9,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import zipgo.auth.exception.AuthException;
 import zipgo.common.config.JwtCredentials;
+
+import static io.jsonwebtoken.SignatureAlgorithm.HS256;
+import static io.jsonwebtoken.security.Keys.hmacShaKeyFor;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)

--- a/backend/src/test/java/zipgo/brand/domain/BrandTest.java
+++ b/backend/src/test/java/zipgo/brand/domain/BrandTest.java
@@ -1,8 +1,8 @@
 package zipgo.brand.domain;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class BrandTest {
 

--- a/backend/src/test/java/zipgo/common/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/zipgo/common/GlobalExceptionHandlerTest.java
@@ -1,9 +1,5 @@
 package zipgo.common;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -15,6 +11,10 @@ import org.springframework.web.HttpMediaTypeNotSupportedException;
 import zipgo.acceptance.AcceptanceTest;
 import zipgo.petfood.presentation.dto.ErrorResponse;
 import zipgo.review.presentation.ReviewController;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class GlobalExceptionHandlerTest extends AcceptanceTest {

--- a/backend/src/test/java/zipgo/member/application/MemberQueryServiceTest.java
+++ b/backend/src/test/java/zipgo/member/application/MemberQueryServiceTest.java
@@ -1,8 +1,5 @@
 package zipgo.member.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static zipgo.member.domain.fixture.MemberFixture.식별자_없는_멤버;
-
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -11,6 +8,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import zipgo.member.domain.Member;
 import zipgo.member.domain.repository.MemberRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipgo.member.domain.fixture.MemberFixture.식별자_없는_멤버;
 
 @Transactional
 @SpringBootTest

--- a/backend/src/test/java/zipgo/member/domain/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/zipgo/member/domain/repository/MemberRepositoryTest.java
@@ -1,14 +1,14 @@
 package zipgo.member.domain.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static zipgo.member.domain.fixture.MemberFixture.식별자_없는_멤버;
-
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import zipgo.member.domain.Member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static zipgo.member.domain.fixture.MemberFixture.식별자_없는_멤버;
 
 @DataJpaTest
 @SuppressWarnings("NonAsciiCharacters")

--- a/backend/src/test/java/zipgo/petfood/application/PetFoodQueryServiceTest.java
+++ b/backend/src/test/java/zipgo/petfood/application/PetFoodQueryServiceTest.java
@@ -170,20 +170,6 @@ class PetFoodQueryServiceTest {
     class 상세_조회 {
 
         @Test
-        void 아이디로_식품을_조회할_수_있다() {
-            // given
-            Brand 브랜드 = brandRepository.findAll().get(0);
-            PetFood 테스트용_식품 = 키워드_없이_식품_초기화(브랜드);
-            Long 아이디 = petFoodRepository.save(테스트용_식품).getId();
-
-            // when
-            PetFood 조회된_식품 = petFoodQueryService.getPetFoodBy(아이디);
-
-            // then
-            assertThat(조회된_식품).isEqualTo(테스트용_식품);
-        }
-
-        @Test
         void 식품_상세조회할수_있다() {
             //given
             Brand 브랜드 = brandRepository.findAll().get(0);

--- a/backend/src/test/java/zipgo/petfood/application/PetFoodQueryServiceTest.java
+++ b/backend/src/test/java/zipgo/petfood/application/PetFoodQueryServiceTest.java
@@ -1,11 +1,5 @@
 package zipgo.petfood.application;
 
-import static java.util.Collections.EMPTY_LIST;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static zipgo.petfood.domain.fixture.PetFoodFixture.키워드_없이_식품_초기화;
-import static zipgo.petfood.domain.fixture.PetFoodFixture.키워드_있는_식품_초기화;
-
 import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -23,6 +17,13 @@ import zipgo.petfood.domain.PetFood;
 import zipgo.petfood.domain.repository.KeywordRepository;
 import zipgo.petfood.domain.repository.PetFoodRepository;
 import zipgo.petfood.presentation.dto.FilterResponse;
+import zipgo.petfood.presentation.dto.GetPetFoodResponse;
+
+import static java.util.Collections.EMPTY_LIST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static zipgo.petfood.domain.fixture.PetFoodFixture.키워드_없이_식품_초기화;
+import static zipgo.petfood.domain.fixture.PetFoodFixture.키워드_있는_식품_초기화;
 
 @SpringBootTest
 @SuppressWarnings("NonAsciiCharacters")
@@ -162,6 +163,51 @@ class PetFoodQueryServiceTest {
             // then
             assertThat(petFoods.size()).isEqualTo(petFoodRepository.findAll().size());
         }
+
+    }
+
+    @Nested
+    class 상세_조회 {
+
+        @Test
+        void 아이디로_식품을_조회할_수_있다() {
+            // given
+            Brand 브랜드 = brandRepository.findAll().get(0);
+            PetFood 테스트용_식품 = 키워드_없이_식품_초기화(브랜드);
+            Long 아이디 = petFoodRepository.save(테스트용_식품).getId();
+
+            // when
+            PetFood 조회된_식품 = petFoodQueryService.getPetFoodBy(아이디);
+
+            // then
+            assertThat(조회된_식품).isEqualTo(테스트용_식품);
+        }
+
+        @Test
+        void 식품_상세조회할수_있다() {
+            //given
+            Brand 브랜드 = brandRepository.findAll().get(0);
+            PetFood 테스트용_식품 = 키워드_없이_식품_초기화(브랜드);
+            Long 아이디 = petFoodRepository.save(테스트용_식품).getId();
+
+            //when
+            GetPetFoodResponse 응답 = petFoodQueryService.getPetFoodResponse(아이디);
+
+            //then
+            assertThat(응답.id()).isEqualTo(테스트용_식품.getId());
+            assertThat(응답.name()).isEqualTo(테스트용_식품.getName());
+            assertThat(응답.imageUrl()).isEqualTo(테스트용_식품.getImageUrl());
+            assertThat(응답.purchaseUrl()).isEqualTo(테스트용_식품.getPurchaseLink());
+            assertThat(응답.brand().name()).isEqualTo(브랜드.getName());
+            assertThat(응답.brand().foundedYear()).isEqualTo(브랜드.getFoundedYear());
+            assertThat(응답.brand().nation()).isEqualTo(브랜드.getNation());
+            assertThat(응답.rating()).isEqualTo(0);
+            assertThat(응답.reviewCount()).isEqualTo(0);
+            assertThat(응답.hasStandard().hasEuStandard()).isTrue();
+            assertThat(응답.hasStandard().hasUsStandard()).isTrue();
+            assertThat(응답.functionality()).containsAll(테스트용_식품.getFunctionality());
+        }
+
     }
 
     @Test
@@ -198,19 +244,6 @@ class PetFoodQueryServiceTest {
         assertThat(responses).hasSize(0);
     }
 
-    @Test
-    void 아이디로_식품을_조회할_수_있다() {
-        // given
-        Brand 브랜드 = brandRepository.findAll().get(0);
-        PetFood 테스트용_식품 = 키워드_없이_식품_초기화(브랜드);
-        Long 아이디 = petFoodRepository.save(테스트용_식품).getId();
-
-        // when
-        PetFood 조회된_식품 = petFoodQueryService.getPetFoodBy(아이디);
-
-        // then
-        assertThat(조회된_식품).isEqualTo(테스트용_식품);
-    }
 
     @Test
 //    @Disabled("230802 메타데이터 API 요구사항 변경사항 반영 전 비활성화")

--- a/backend/src/test/java/zipgo/petfood/application/PetFoodQueryServiceUnitTest.java
+++ b/backend/src/test/java/zipgo/petfood/application/PetFoodQueryServiceUnitTest.java
@@ -1,11 +1,5 @@
 package zipgo.petfood.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.Mockito.when;
-import static zipgo.brand.domain.fixture.BrandFixture.식품_브랜드_생성하기;
-import static zipgo.petfood.domain.fixture.PetFoodFixture.키워드_있는_식품_초기화;
-
 import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
@@ -21,6 +15,12 @@ import zipgo.petfood.domain.PetFood;
 import zipgo.petfood.domain.repository.PetFoodQueryRepository;
 import zipgo.petfood.domain.repository.PetFoodRepository;
 import zipgo.petfood.presentation.dto.FilterResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.when;
+import static zipgo.brand.domain.fixture.BrandFixture.식품_브랜드_생성하기;
+import static zipgo.petfood.domain.fixture.PetFoodFixture.키워드_있는_식품_초기화;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(ReplaceUnderscores.class)

--- a/backend/src/test/java/zipgo/petfood/domain/KeywordTest.java
+++ b/backend/src/test/java/zipgo/petfood/domain/KeywordTest.java
@@ -1,10 +1,10 @@
 package zipgo.petfood.domain;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)

--- a/backend/src/test/java/zipgo/petfood/domain/PetFoodTest.java
+++ b/backend/src/test/java/zipgo/petfood/domain/PetFoodTest.java
@@ -1,10 +1,10 @@
 package zipgo.petfood.domain;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)

--- a/backend/src/test/java/zipgo/petfood/domain/ReviewsTest.java
+++ b/backend/src/test/java/zipgo/petfood/domain/ReviewsTest.java
@@ -1,8 +1,5 @@
 package zipgo.petfood.domain;
 
-import static java.util.Collections.emptyList;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -13,6 +10,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import zipgo.review.domain.Review;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)

--- a/backend/src/test/java/zipgo/petfood/domain/fixture/PetFoodFixture.java
+++ b/backend/src/test/java/zipgo/petfood/domain/fixture/PetFoodFixture.java
@@ -1,7 +1,5 @@
 package zipgo.petfood.domain.fixture;
 
-import static zipgo.petfood.domain.PrimaryIngredients.builder;
-
 import java.util.List;
 import zipgo.brand.domain.Brand;
 import zipgo.petfood.domain.Functionality;
@@ -9,6 +7,8 @@ import zipgo.petfood.domain.HasStandard;
 import zipgo.petfood.domain.Keyword;
 import zipgo.petfood.domain.PetFood;
 import zipgo.petfood.domain.PrimaryIngredients;
+
+import static zipgo.petfood.domain.PrimaryIngredients.builder;
 
 public class PetFoodFixture {
 
@@ -19,6 +19,8 @@ public class PetFoodFixture {
                 .purchaseLink("https://avatars.githubusercontent.com/u/94087228?v=4")
                 .brand(brand)
                 .hasStandard(HasStandard.builder().build())
+                .functionality(Functionality.builder().build())
+                .primaryIngredients(PrimaryIngredients.builder().build())
                 .build();
     }
 
@@ -41,6 +43,7 @@ public class PetFoodFixture {
                 .imageUrl("imageUrl")
                 .purchaseLink("purchaseLink")
                 .brand(brand)
+                .functionality(Functionality.builder().build())
                 .primaryIngredients(builder().primaryIngredients(List.of("닭고기", "쌀", "귀리", "보리")).build())
                 .hasStandard(HasStandard.builder().build())
                 .build();

--- a/backend/src/test/java/zipgo/petfood/domain/repository/KeywordRepositoryTest.java
+++ b/backend/src/test/java/zipgo/petfood/domain/repository/KeywordRepositoryTest.java
@@ -1,7 +1,5 @@
 package zipgo.petfood.domain.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -9,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import zipgo.petfood.domain.Keyword;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @SuppressWarnings("NonAsciiCharacters")

--- a/backend/src/test/java/zipgo/petfood/infra/persist/PetFoodRepositoryImplTest.java
+++ b/backend/src/test/java/zipgo/petfood/infra/persist/PetFoodRepositoryImplTest.java
@@ -1,8 +1,5 @@
 package zipgo.petfood.infra.persist;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +10,9 @@ import org.springframework.test.context.jdbc.Sql;
 import zipgo.common.config.QueryDslTestConfig;
 import zipgo.petfood.domain.PetFood;
 import zipgo.petfood.domain.repository.PetFoodQueryRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataJpaTest
 @Import(QueryDslTestConfig.class)
@@ -37,7 +37,8 @@ class PetFoodRepositoryImplTest {
         assertAll(
                 () -> assertThat(petFoods).extracting(petFood -> petFood.getKeyword().getName()).contains(keyword),
                 () -> assertThat(petFoods).extracting(petFood -> petFood.getBrand().getName()).contains(brand),
-                () -> assertThat(petFoods).extracting(petFood -> petFood.getPrimaryIngredients()).contains(List.of(primaryIngredients)),
+                () -> assertThat(petFoods).extracting(petFood -> petFood.getPrimaryIngredients())
+                        .contains(List.of(primaryIngredients)),
                 () -> assertThat(petFoods).hasSize(1)
         );
     }

--- a/backend/src/test/java/zipgo/review/application/ReviewQueryServiceTest.java
+++ b/backend/src/test/java/zipgo/review/application/ReviewQueryServiceTest.java
@@ -1,18 +1,5 @@
 package zipgo.review.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static zipgo.brand.domain.fixture.BrandFixture.식품_브랜드_생성하기;
-import static zipgo.petfood.domain.fixture.PetFoodFixture.키워드_없이_식품_초기화;
-import static zipgo.review.domain.type.AdverseReactionType.NONE;
-import static zipgo.review.domain.type.StoolCondition.SOFT_MOIST;
-import static zipgo.review.domain.type.TastePreference.EATS_VERY_WELL;
-import static zipgo.review.fixture.AdverseReactionFixture.눈물_이상반응;
-import static zipgo.review.fixture.AdverseReactionFixture.먹고_토_이상반응;
-import static zipgo.review.fixture.MemberFixture.무민;
-import static zipgo.review.fixture.ReviewFixture.극찬_리뷰_생성;
-import static zipgo.review.fixture.ReviewFixture.혹평_리뷰_생성;
-
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +12,19 @@ import zipgo.petfood.domain.PetFood;
 import zipgo.petfood.domain.repository.PetFoodRepository;
 import zipgo.review.domain.Review;
 import zipgo.review.domain.repository.ReviewRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static zipgo.brand.domain.fixture.BrandFixture.식품_브랜드_생성하기;
+import static zipgo.petfood.domain.fixture.PetFoodFixture.키워드_없이_식품_초기화;
+import static zipgo.review.domain.type.AdverseReactionType.NONE;
+import static zipgo.review.domain.type.StoolCondition.SOFT_MOIST;
+import static zipgo.review.domain.type.TastePreference.EATS_VERY_WELL;
+import static zipgo.review.fixture.AdverseReactionFixture.눈물_이상반응;
+import static zipgo.review.fixture.AdverseReactionFixture.먹고_토_이상반응;
+import static zipgo.review.fixture.MemberFixture.무민;
+import static zipgo.review.fixture.ReviewFixture.극찬_리뷰_생성;
+import static zipgo.review.fixture.ReviewFixture.혹평_리뷰_생성;
 
 class ReviewQueryServiceTest extends QueryServiceTest {
 
@@ -50,7 +50,8 @@ class ReviewQueryServiceTest extends QueryServiceTest {
         Member 멤버 = memberRepository.save(무민());
         petFoodRepository.save(식품);
         Review 극찬_리뷰 = reviewRepository.save(극찬_리뷰_생성(멤버, 식품));
-        Review 혹평_리뷰_생성 = 혹평_리뷰_생성(멤버, 식품, List.of(눈물_이상반응().getAdverseReactionType().getDescription(), 먹고_토_이상반응().getAdverseReactionType().getDescription()));
+        Review 혹평_리뷰_생성 = 혹평_리뷰_생성(멤버, 식품, List.of(눈물_이상반응().getAdverseReactionType().getDescription(),
+                먹고_토_이상반응().getAdverseReactionType().getDescription()));
         reviewRepository.save(혹평_리뷰_생성);
 
         //when

--- a/backend/src/test/java/zipgo/review/application/ReviewServiceTest.java
+++ b/backend/src/test/java/zipgo/review/application/ReviewServiceTest.java
@@ -1,21 +1,5 @@
 package zipgo.review.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static zipgo.brand.domain.fixture.BrandFixture.식품_브랜드_생성하기;
-import static zipgo.petfood.domain.fixture.PetFoodFixture.키워드_없이_식품_초기화;
-import static zipgo.review.domain.type.StoolCondition.SOFT_MOIST;
-import static zipgo.review.domain.type.StoolCondition.UNCERTAIN;
-import static zipgo.review.domain.type.TastePreference.EATS_MODERATELY;
-import static zipgo.review.domain.type.TastePreference.EATS_VERY_WELL;
-import static zipgo.review.fixture.AdverseReactionFixture.눈물_이상반응;
-import static zipgo.review.fixture.AdverseReactionFixture.먹고_토_이상반응;
-import static zipgo.review.fixture.MemberFixture.무민;
-import static zipgo.review.fixture.ReviewFixture.리뷰_생성_요청;
-import static zipgo.review.fixture.ReviewFixture.리뷰_수정_요청;
-import static zipgo.review.fixture.ReviewFixture.혹평_리뷰_생성;
-
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -35,6 +19,22 @@ import zipgo.review.dto.request.CreateReviewRequest;
 import zipgo.review.exception.ReviewException;
 import zipgo.review.exception.StoolConditionException;
 import zipgo.review.exception.TastePreferenceException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static zipgo.brand.domain.fixture.BrandFixture.식품_브랜드_생성하기;
+import static zipgo.petfood.domain.fixture.PetFoodFixture.키워드_없이_식품_초기화;
+import static zipgo.review.domain.type.StoolCondition.SOFT_MOIST;
+import static zipgo.review.domain.type.StoolCondition.UNCERTAIN;
+import static zipgo.review.domain.type.TastePreference.EATS_MODERATELY;
+import static zipgo.review.domain.type.TastePreference.EATS_VERY_WELL;
+import static zipgo.review.fixture.AdverseReactionFixture.눈물_이상반응;
+import static zipgo.review.fixture.AdverseReactionFixture.먹고_토_이상반응;
+import static zipgo.review.fixture.MemberFixture.무민;
+import static zipgo.review.fixture.ReviewFixture.리뷰_생성_요청;
+import static zipgo.review.fixture.ReviewFixture.리뷰_수정_요청;
+import static zipgo.review.fixture.ReviewFixture.혹평_리뷰_생성;
 
 class ReviewServiceTest extends ServiceTest {
 
@@ -177,7 +177,8 @@ class ReviewServiceTest extends ServiceTest {
         Member 멤버 = memberRepository.save(무민());
         petFoodRepository.save(식품);
         Review 리뷰 = reviewRepository.save(혹평_리뷰_생성(멤버, 식품,
-                List.of(눈물_이상반응().getAdverseReactionType().getDescription(), 먹고_토_이상반응().getAdverseReactionType().getDescription())));
+                List.of(눈물_이상반응().getAdverseReactionType().getDescription(),
+                        먹고_토_이상반응().getAdverseReactionType().getDescription())));
 
         //when
         reviewService.deleteReview(멤버.getId(), 리뷰.getId());

--- a/backend/src/test/java/zipgo/review/fixture/AdverseReactionFixture.java
+++ b/backend/src/test/java/zipgo/review/fixture/AdverseReactionFixture.java
@@ -1,9 +1,9 @@
 package zipgo.review.fixture;
 
+import zipgo.review.domain.AdverseReaction;
+
 import static zipgo.review.domain.type.AdverseReactionType.TEARS;
 import static zipgo.review.domain.type.AdverseReactionType.VOMITING;
-
-import zipgo.review.domain.AdverseReaction;
 
 public class AdverseReactionFixture {
 

--- a/backend/src/test/java/zipgo/review/fixture/ReviewFixture.java
+++ b/backend/src/test/java/zipgo/review/fixture/ReviewFixture.java
@@ -1,10 +1,5 @@
 package zipgo.review.fixture;
 
-import static zipgo.review.domain.type.StoolCondition.DIARRHEA;
-import static zipgo.review.domain.type.StoolCondition.SOFT_MOIST;
-import static zipgo.review.domain.type.TastePreference.EATS_VERY_WELL;
-import static zipgo.review.domain.type.TastePreference.NOT_AT_ALL;
-
 import java.util.ArrayList;
 import java.util.List;
 import zipgo.member.domain.Member;
@@ -14,6 +9,11 @@ import zipgo.review.domain.Review;
 import zipgo.review.domain.type.AdverseReactionType;
 import zipgo.review.dto.request.CreateReviewRequest;
 import zipgo.review.dto.request.UpdateReviewRequest;
+
+import static zipgo.review.domain.type.StoolCondition.DIARRHEA;
+import static zipgo.review.domain.type.StoolCondition.SOFT_MOIST;
+import static zipgo.review.domain.type.TastePreference.EATS_VERY_WELL;
+import static zipgo.review.domain.type.TastePreference.NOT_AT_ALL;
 
 public class ReviewFixture {
 

--- a/backend/src/test/java/zipgo/review/presentation/ReviewControllerTest.java
+++ b/backend/src/test/java/zipgo/review/presentation/ReviewControllerTest.java
@@ -1,5 +1,14 @@
 package zipgo.review.presentation;
 
+import com.epages.restdocs.apispec.ResourceSnippetDetails;
+import com.epages.restdocs.apispec.Schema;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.restassured.RestDocumentationFilter;
+import zipgo.acceptance.AcceptanceTest;
+
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.resourceDetails;
 import static com.epages.restdocs.apispec.Schema.schema;
@@ -20,15 +29,6 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static zipgo.review.fixture.ReviewFixture.리뷰_생성_요청;
 import static zipgo.review.fixture.ReviewFixture.리뷰_수정_요청;
-
-import com.epages.restdocs.apispec.ResourceSnippetDetails;
-import com.epages.restdocs.apispec.Schema;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.restdocs.restassured.RestDocumentationFilter;
-import zipgo.acceptance.AcceptanceTest;
 
 
 public class ReviewControllerTest extends AcceptanceTest {
@@ -192,6 +192,7 @@ public class ReviewControllerTest extends AcceptanceTest {
             return document("리뷰 생성 - 실패(없는 식품)", 문서_정보.responseSchema(에러_응답_형식),
                     requestHeaders(headerWithName("Authorization").description("인증을 위한 JWT")));
         }
+
     }
 
     @Nested
@@ -266,7 +267,6 @@ public class ReviewControllerTest extends AcceptanceTest {
         }
 
     }
-
 
 
     @Nested


### PR DESCRIPTION
## 📄 Summary
> 
- closes: #85 

식품 상세 조회 API 응답 조립을 컨트롤러에서 하지 않습니다.
이제 osiv가 꺼져도 에러가 나지 않겠지요..?

## 🙋🏻 More
> 
