### PR TITLE
fix: 리뷰 평균을 소수점 한자리 수까지만 응답하도록 함

### DIFF
--- a/backend/src/main/java/zipgo/petfood/domain/Reviews.java
+++ b/backend/src/main/java/zipgo/petfood/domain/Reviews.java
@@ -29,6 +29,10 @@ public class Reviews {
                 .mapToInt(review -> review.getRating())
                 .average()
                 .orElse(0);
+        return roundToOneDecimal(average);
+    }
+
+    private double roundToOneDecimal(double average) {
         return Math.round(average * 10) / 10.0;
     }
 

--- a/backend/src/main/java/zipgo/petfood/domain/Reviews.java
+++ b/backend/src/main/java/zipgo/petfood/domain/Reviews.java
@@ -25,10 +25,11 @@ public class Reviews {
     private List<Review> reviews = new ArrayList<>();
 
     public double calculateRatingAverage() {
-        return reviews.stream()
+        double average = reviews.stream()
                 .mapToInt(review -> review.getRating())
                 .average()
                 .orElse(0);
+        return Math.round(average * 10) / 10.0;
     }
 
     public int countReviews() {

--- a/backend/src/test/java/zipgo/petfood/domain/ReviewsTest.java
+++ b/backend/src/test/java/zipgo/petfood/domain/ReviewsTest.java
@@ -1,8 +1,5 @@
 package zipgo.petfood.domain;
 
-import static java.util.Collections.emptyList;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -13,6 +10,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import zipgo.review.domain.Review;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -44,8 +44,9 @@ class ReviewsTest {
                 Arguments.of(emptyList(), 0),
                 Arguments.of(List.of(1, 2, 3, 4, 5), 3.0),
                 Arguments.of(List.of(2, 3, 3, 5, 5), 3.6),
-                Arguments.of(List.of(1, 2, 4), (double) 7 / 3),
-                Arguments.of(List.of(4, 4, 4, 5, 5), 4.4)
+                Arguments.of(List.of(1, 2, 4), 2.3),
+                Arguments.of(List.of(4, 4, 4, 5, 5), 4.4),
+                Arguments.of(List.of(1, 2, 5), 2.7)
         );
     }
 

--- a/backend/src/test/java/zipgo/petfood/domain/ReviewsTest.java
+++ b/backend/src/test/java/zipgo/petfood/domain/ReviewsTest.java
@@ -31,7 +31,7 @@ class ReviewsTest {
         assertThat(계산_결과).isEqualTo(예상_결과);
     }
 
-    private Reviews 별점으로_리뷰만들기(final List<Integer> 별점_리스트) {
+    private Reviews 별점으로_리뷰만들기(List<Integer> 별점_리스트) {
         List<Review> 리뷰 = 별점_리스트.stream()
                 .map(별점 -> Review.builder().rating(별점).build())
                 .toList();


### PR DESCRIPTION
## 📄 Summary
> 

- closes: #172

## 🙋🏻 More
> 

근데 한 자릿수까지 보여주는 것도 맞는건지는 모르겠어여. 그냥 자연수가 나은가여?