### PR TITLE
feat: 사용자 정보에 반려동물 등록 여부 추가

### DIFF
--- a/backend/src/main/java/zipgo/auth/presentation/dto/AuthResponse.java
+++ b/backend/src/main/java/zipgo/auth/presentation/dto/AuthResponse.java
@@ -4,13 +4,15 @@ import zipgo.member.domain.Member;
 
 public record AuthResponse(
         String name,
-        String profileImgUrl
+        String profileImgUrl,
+        boolean hasPet
 ) {
 
     public static AuthResponse from(Member member) {
         return new AuthResponse(
                 member.getName(),
-                member.getProfileImgUrl()
+                member.getProfileImgUrl(),
+                member.hasPet()
         );
     }
 

--- a/backend/src/main/java/zipgo/member/domain/Member.java
+++ b/backend/src/main/java/zipgo/member/domain/Member.java
@@ -41,4 +41,8 @@ public class Member extends BaseTimeEntity {
     @OneToOne(mappedBy = "owner")
     private Pet pet;
 
+    public boolean hasPet() {
+        return pet != null;
+    }
+
 }

--- a/backend/src/test/java/zipgo/auth/presentation/AuthControllerMockArgumentResolverTest.java
+++ b/backend/src/test/java/zipgo/auth/presentation/AuthControllerMockArgumentResolverTest.java
@@ -90,7 +90,8 @@ class AuthControllerMockArgumentResolverTest {
                 ),
                 responseFields(
                         fieldWithPath("name").description("사용자 이름"),
-                        fieldWithPath("profileImgUrl").description("사용자 프로필 사진")
+                        fieldWithPath("profileImgUrl").description("사용자 프로필 사진"),
+                        fieldWithPath("hasPet").description("반려동물 등록 여부")
                 ));
     }
 

--- a/backend/src/test/java/zipgo/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/zipgo/auth/presentation/AuthControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import zipgo.auth.application.AuthService;
@@ -92,10 +93,12 @@ class AuthControllerTest {
                 문서_정보,
                 queryParameters(parameterWithName("code").optional().description("소셜 로그인 API")),
                 responseFields(
-                        fieldWithPath("accessToken").description("accessToken"),
+                        fieldWithPath("accessToken").description("accessToken").type(JsonFieldType.STRING),
                         fieldWithPath("authResponse").description("로그인 후 필요한 사용자 정보"),
-                        fieldWithPath("authResponse.name").description("사용자 이름"),
+                        fieldWithPath("authResponse.name").description("사용자 이름").type(JsonFieldType.STRING),
                         fieldWithPath("authResponse.profileImgUrl").description("사용자 프로필 사진")
+                                .type(JsonFieldType.STRING),
+                        fieldWithPath("authResponse.hasPet").description("반려동물 등록 여부").type(JsonFieldType.BOOLEAN)
                 ));
     }
 

--- a/backend/src/test/java/zipgo/member/domain/MemberTest.java
+++ b/backend/src/test/java/zipgo/member/domain/MemberTest.java
@@ -1,0 +1,35 @@
+package zipgo.member.domain;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import zipgo.pet.domain.Pet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberTest {
+
+    @Nested
+    class 반려동물_여부를_확인 {
+
+        @Test
+        void 반려동물이_있을때_true() {
+            //given
+            Pet 반려동물 = Pet.builder().build();
+            Member 주인 = Member.builder().pet(반려동물).build();
+
+            // expect
+            assertThat(주인.hasPet()).isTrue();
+        }
+
+        @Test
+        void 반려동물이_없을때_true() {
+            //given
+            Member 주인 = Member.builder().build();
+
+            // expect
+            assertThat(주인.hasPet()).isFalse();
+        }
+
+    }
+
+}


### PR DESCRIPTION
## 📄 Summary
> 

- closes: #244 

이 값은 맞춤리뷰 기능을 반려동물이 있는 회원으로 제한하기 위해 프론트엔드에서 알아야하는 값입니다.
<img width="214" alt="image" src="https://github.com/woowacourse-teams/2023-zipgo/assets/61582017/8182d153-cd6e-4b4f-a3c1-cae2fa4aea08">


## 🙋🏻 More
> 
