### PR TITLE
hotfix: aws 인증정보 사용시 ec2 내부의 기본 프로필을 사용하도록 변경

### DIFF
--- a/backend/src/main/java/zipgo/common/config/S3Config.java
+++ b/backend/src/main/java/zipgo/common/config/S3Config.java
@@ -13,7 +13,7 @@ public class S3Config {
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
-                .credentialsProvider(InstanceProfileCredentialsProvider.create())
+                .credentialsProvider(InstanceProfileCredentialsProvider.builder().build())
                 .region(AP_NORTHEAST_2)
                 .build();
     }

--- a/backend/src/main/java/zipgo/common/config/S3Config.java
+++ b/backend/src/main/java/zipgo/common/config/S3Config.java
@@ -2,7 +2,7 @@ package zipgo.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import static software.amazon.awssdk.regions.Region.AP_NORTHEAST_2;
@@ -13,7 +13,7 @@ public class S3Config {
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
-                .credentialsProvider(ProfileCredentialsProvider.create())
+                .credentialsProvider(InstanceProfileCredentialsProvider.builder().build())
                 .region(AP_NORTHEAST_2)
                 .build();
     }

--- a/backend/src/main/java/zipgo/common/config/S3Config.java
+++ b/backend/src/main/java/zipgo/common/config/S3Config.java
@@ -13,7 +13,7 @@ public class S3Config {
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
-                .credentialsProvider(InstanceProfileCredentialsProvider.builder().build())
+                .credentialsProvider(InstanceProfileCredentialsProvider.create())
                 .region(AP_NORTHEAST_2)
                 .build();
     }


### PR DESCRIPTION
## 📄 Summary
> #237 

## 🙋🏻 More
>  EC2 인스턴스 내 기본 프로필을 사용하도록 변경
