### PR TITLE
fix: 식품 상세 페이지 기능성 라벨 깨짐 수정

### DIFF
--- a/frontend/src/components/@common/ToolTip/ToolTip.tsx
+++ b/frontend/src/components/@common/ToolTip/ToolTip.tsx
@@ -33,6 +33,7 @@ const ToolTip = (props: ToolTipProps) => {
 
   return (
     <ToolTipWrapper>
+      <BackDrop />
       {!showBubbleOnly && (
         <ToolTipContainer type="button" onClick={onClickToolTip}>
           <img src={ToolTipButton} alt="tooltip" />
@@ -52,6 +53,15 @@ export default ToolTip;
 
 interface BubbleWrapperProps
   extends StyledProps<Pick<ToolTipProps, 'width' | 'direction' | 'left' | 'edgeLeft'>> {}
+
+const BackDrop = styled.div`
+  position: fixed;
+  z-index: 1;
+  inset: 0;
+
+  width: 100vw;
+  height: 100vh;
+`;
 
 const ToolTipWrapper = styled.div`
   position: absolute;

--- a/frontend/src/pages/FoodDetail/FoodDetail.tsx
+++ b/frontend/src/pages/FoodDetail/FoodDetail.tsx
@@ -156,7 +156,7 @@ const NutritionText = styled.p`
 
 const FunctionalList = styled.div`
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   gap: 0.8rem;
 `;
 


### PR DESCRIPTION
## 📄 Summary
> close #305 

<img width="372" alt="스크린샷 2023-08-17 오후 5 55 55" src="https://github.com/woowacourse-teams/2023-zipgo/assets/72087183/43ba695c-ca19-4f59-9616-f6651d4f5b48">

이렇게 고쳤습니다.

추가로 라벨 바깥 눌렀을 때 꺼지게 만듬

## 🙋🏻 More
> 
