### PR TITLE
fix: 로그아웃 시 로컬스토리지에 petProfile이 남아있도록 수정

### DIFF
--- a/frontend/src/hooks/auth.ts
+++ b/frontend/src/hooks/auth.ts
@@ -16,7 +16,6 @@ export const useAuth = () => {
     if (isLogout) {
       localStorage.removeItem('auth');
       localStorage.removeItem('userInfo');
-      localStorage.removeItem('petProfile');
     }
   };
 


### PR DESCRIPTION
## 📄 Summary
> 
로그아웃할 때 로컬스토리지에 있는 정보들을 삭제해서 로그인했을 때 펫정보를 못 불러오는 문제가 있어서
일단은 로그아웃 시 로컬스토리지에 petProfile이 남아있도록 수정했습니다.

그런데 다른 브라우저로 접속하거나 로컬스토리지를 비우면 또 같은 문제가 생길테니.. 추후에 다른 방법으로 해결해야할 것 같아요!
## 🙋🏻 More
> 
