### PR TITLE
fix: optional auth argument resolver 추가

### DIFF
--- a/backend/src/main/java/zipgo/common/config/WebConfig.java
+++ b/backend/src/main/java/zipgo/common/config/WebConfig.java
@@ -9,6 +9,7 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import zipgo.auth.presentation.AuthInterceptor;
 import zipgo.auth.presentation.JwtMandatoryArgumentResolver;
+import zipgo.auth.presentation.OptionalJwtArgumentResolver;
 import zipgo.auth.support.JwtProvider;
 
 import static org.springframework.http.HttpHeaders.LOCATION;
@@ -43,6 +44,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new JwtMandatoryArgumentResolver(jwtProvider));
+        resolvers.add(new OptionalJwtArgumentResolver(jwtProvider));
     }
 
 }

--- a/backend/src/main/java/zipgo/review/presentation/ReviewController.java
+++ b/backend/src/main/java/zipgo/review/presentation/ReviewController.java
@@ -2,6 +2,7 @@ package zipgo.review.presentation;
 
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -48,15 +49,21 @@ public class ReviewController {
     public ResponseEntity<GetReviewsResponse> getAllReviews(
             @OptionalAuth AuthDto authDto,
             @ModelAttribute @Valid GetReviewsRequest request) {
-        GetReviewsResponse reviews = reviewQueryService.getReviews(request.toQueryRequest(authDto.id()));
+        Long memberId = getMemberId(authDto);
+        GetReviewsResponse reviews = reviewQueryService.getReviews(request.toQueryRequest(memberId));
 
         return ResponseEntity.ok(reviews);
+    }
+
+    private Long getMemberId(AuthDto authDto) {
+        return Optional.ofNullable(authDto).map(AuthDto::id).orElse(null);
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<GetReviewResponse> getReview(@OptionalAuth AuthDto authDto, @PathVariable Long id) {
         Review review = reviewQueryService.getReview(id);
-        return ResponseEntity.ok(GetReviewResponse.from(review, authDto.id()));
+        Long memberId = getMemberId(authDto);
+        return ResponseEntity.ok(GetReviewResponse.from(review, memberId));
     }
 
     @PutMapping("/{reviewId}")

--- a/backend/src/test/java/zipgo/review/presentation/ReviewControllerTest.java
+++ b/backend/src/test/java/zipgo/review/presentation/ReviewControllerTest.java
@@ -2,6 +2,7 @@ package zipgo.review.presentation;
 
 import com.epages.restdocs.apispec.ResourceSnippetDetails;
 import com.epages.restdocs.apispec.Schema;
+import io.restassured.response.Response;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -591,14 +592,20 @@ public class ReviewControllerTest extends AcceptanceTest {
                     .filter(API_문서("리뷰 도움이 돼요 추가 - 성공"));
 
             //when
-            var 응답 = 요청_준비.when()
+            요청_준비.when()
                     .header(AUTHORIZATION, "Bearer " + 다른_회원의_JWT)
                     .pathParam("reviewId", 리뷰.getId())
                     .post("/reviews/{reviewId}/helpful-reactions");
 
             //then
-            응답.then()
-                    .assertThat().statusCode(OK.value());
+            Response 조회_응답 = given().spec(spec)
+                    .contentType(JSON)
+                    .header(AUTHORIZATION, "Bearer " + 다른_회원의_JWT)
+                    .get("/reviews/{reviewId}", 리뷰.getId());
+
+            조회_응답.then()
+                    .log().all()
+                    .assertThat().body("helpfulReaction.reacted", is(true));
         }
 
         @Test


### PR DESCRIPTION
## 📄 Summary
> 내가 누른 도움이 돼요인데 누름 여부가 false로 응답되는 버그 해결

### 문제 상황
- 도움이 돼요를 누른다
- 도움이 돼요 숫자는 늘어나지만, 누름 여부는 여전히 false로 응답이 된다.

### 원인

원인은 제가 리뷰 조회 API 에서 새로 만든 OptionalAuthArgumentResolver가 등록되지 않았던 것입니다.
argument resolver가 등록되지 않았으니, 요청에 jwt가 포함되어도 authDto에 해당하는 인수는 들어오지 않게 되고
```java
@GetMapping
public ResponseEntity<GetReviewsResponse> getAllReviews(
        @OptionalAuth AuthDto authDto, // null
        @ModelAttribute @Valid GetReviewsRequest request) {
    GetReviewsResponse reviews = reviewQueryService.getReviews(request.toQueryRequest(authDto.id()));

    return ResponseEntity.ok(reviews);
}
```
따라서, 회원임에도 불구하고 항상 비회원의 요청인 것 처럼 누름 여부가 항상 false로 계산되었던 것입니다 :D

## 🙋🏻 More
> 무민이 제보해주셨습니다 :D 감사합니다.
