### PR TITLE
feat: 로그인 여부 확인 로직 수정, zipgoLocalStorage 추가

### DIFF
--- a/frontend/src/apis/auth.ts
+++ b/frontend/src/apis/auth.ts
@@ -4,6 +4,7 @@ import {
   LoginZipgoAuthReq,
   LoginZipgoAuthRes,
 } from '@/types/auth/remote';
+import { zipgoLocalStorage } from '@/utils/localStorage';
 
 import { client, clientBasic, createConfigWithAuth } from '.';
 
@@ -29,6 +30,7 @@ export const logoutKaKaoAuth = async () => {
     null,
     {
       headers: {
+        /** @todo kakao logout 여부 논의 */
         Authorization: `Bearer ${localStorage.getItem('kakao')}`,
       },
     },

--- a/frontend/src/apis/auth.ts
+++ b/frontend/src/apis/auth.ts
@@ -5,7 +5,7 @@ import {
   LoginZipgoAuthRes,
 } from '@/types/auth/remote';
 
-import { client, clientBasic } from '.';
+import { client, clientBasic, createConfigWithAuth } from '.';
 
 export const loginZipgoAuth = async ({ code }: LoginZipgoAuthReq) => {
   const { data } = await client.post<LoginZipgoAuthRes>('/auth/login', null, {
@@ -38,11 +38,12 @@ export const logoutKaKaoAuth = async () => {
 };
 
 export const authenticateUser = async () => {
-  const { data } = await clientBasic.get<AuthenticateUserRes>('/auth', {
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem('auth')}`,
-    },
-  });
+  const tokens = zipgoLocalStorage.getTokens();
+
+  const { data } = await clientBasic.get<AuthenticateUserRes>(
+    '/auth',
+    createConfigWithAuth(tokens),
+  );
 
   return data;
 };

--- a/frontend/src/apis/index.ts
+++ b/frontend/src/apis/index.ts
@@ -1,14 +1,25 @@
 import axios from 'axios';
 
+import { Tokens } from '@/types/auth/client';
+import { zipgoLocalStorage } from '@/utils/localStorage';
+
 export const { BASE_URL } = process.env;
 
-export const clientBasic = axios.create({
-  baseURL: BASE_URL,
-});
+const tokens = zipgoLocalStorage.getTokens();
 
-export const client = axios.create({
+const defaultConfig = {
   baseURL: BASE_URL,
-  headers: {
-    Authorization: `Bearer ${localStorage.getItem('auth')}`,
-  },
-});
+};
+
+export const createConfigWithAuth = (tokens: Tokens | null) =>
+  tokens
+    ? Object.assign(defaultConfig, {
+        headers: {
+          Authorization: `Bearer ${tokens.accessToken}`,
+        },
+      })
+    : defaultConfig;
+
+export const clientBasic = axios.create(defaultConfig);
+
+export const client = axios.create(createConfigWithAuth(tokens));

--- a/frontend/src/components/@common/AxiosInterceptors/AxiosInterceptors.tsx
+++ b/frontend/src/components/@common/AxiosInterceptors/AxiosInterceptors.tsx
@@ -3,6 +3,7 @@ import { PropsWithChildren, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { client } from '@/apis';
+import { zipgoLocalStorage } from '@/utils/localStorage';
 
 const AxiosInterceptors = (props: PropsWithChildren) => {
   const { children } = props;
@@ -11,11 +12,11 @@ const AxiosInterceptors = (props: PropsWithChildren) => {
 
   useEffect(() => {
     const requestInterceptor = client.interceptors.request.use(config => {
-      const accessToken = localStorage.getItem('auth');
+      const tokens = zipgoLocalStorage.getTokens();
 
-      if (accessToken) {
+      if (tokens) {
         // eslint-disable-next-line no-param-reassign
-        config.headers.Authorization = `Bearer ${accessToken}`;
+        config.headers.Authorization = `Bearer ${tokens.accessToken}`;
       }
 
       return config;
@@ -28,9 +29,9 @@ const AxiosInterceptors = (props: PropsWithChildren) => {
 
         if (error.response && error.response.status === 401) {
           alert('세션이 만료되었습니다.');
-          localStorage.removeItem('auth');
-          localStorage.removeItem('userInfo');
-          localStorage.removeItem('petProfile');
+
+          zipgoLocalStorage.clearAuth();
+
           navigate('/login');
         }
 

--- a/frontend/src/components/Review/ReviewItem/ReviewItem.tsx
+++ b/frontend/src/components/Review/ReviewItem/ReviewItem.tsx
@@ -8,17 +8,18 @@ import UnReactedIcon from '@/assets/svg/un_reacted_icon.svg';
 import StarRatingDisplay from '@/components/@common/StarRating/StarRatingDisplay/StartRatingDisplay';
 import { COMMENT_VISIABLE_LINE_LIMIT, REACTIONS } from '@/constants/review';
 import { useValidParams } from '@/hooks/@common/useValidParams';
-import { useAuth, useUser } from '@/hooks/auth';
+import { useAuth } from '@/hooks/auth';
 import { useRemoveReviewMutation, useToggleHelpfulReactionMutation } from '@/hooks/query/review';
 import { routerPath } from '@/router/routes';
 import { Review } from '@/types/review/client';
+import { zipgoLocalStorage } from '@/utils/localStorage';
 
 interface ReviewItemProps extends Review {}
 
 const ReviewItem = (reviewItemProps: ReviewItemProps) => {
   /** @todo 본인 리뷰 확인 - 추후 id로 변경 */
   const { isLoggedIn } = useAuth();
-  const { petProfile } = useUser();
+  const petProfile = zipgoLocalStorage.getPetProfile();
 
   const {
     id: reviewId,

--- a/frontend/src/components/Review/ReviewList/ReviewList.tsx
+++ b/frontend/src/components/Review/ReviewList/ReviewList.tsx
@@ -7,6 +7,7 @@ import { useValidParams } from '@/hooks/@common/useValidParams';
 import useValidQueryString from '@/hooks/common/useValidQueryString';
 import { useReviewListQuery } from '@/hooks/query/review';
 import { routerPath } from '@/router/routes';
+import { zipgoLocalStorage } from '@/utils/localStorage';
 
 import ReviewItem from '../ReviewItem/ReviewItem';
 import ReviewControls from './ReviewControls/ReviewControls';
@@ -25,10 +26,7 @@ const ReviewList = () => {
     sortById: queryString.sortBy,
   });
 
-  const { hasPet } = JSON.parse(
-    localStorage.getItem('userInfo') ??
-      JSON.stringify({ name: '', profileImageUrl: null, hasPet: false }),
-  );
+  const userInfo = zipgoLocalStorage.getUserInfo();
 
   const goReviewWrite = () => navigate(routerPath.reviewStarRating({ petFoodId }));
 
@@ -55,7 +53,7 @@ const ReviewList = () => {
           해당 식품의 첫 번째 리뷰어가 되어보세요!
         </NoReviewText>
       )}
-      {hasPet && (
+      {userInfo?.hasPet && (
         <ReviewAddButton type="button" aria-label="리뷰 작성" onClick={goReviewWrite}>
           <WriteIconImage src={WriteIcon} alt="" />
         </ReviewAddButton>

--- a/frontend/src/context/petProfile/PetProfileContext.tsx
+++ b/frontend/src/context/petProfile/PetProfileContext.tsx
@@ -1,15 +1,10 @@
-import { createContext, PropsWithChildren, useEffect, useMemo, useState } from 'react';
+import { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
 
 import { PetProfile } from '@/types/petProfile/client';
-
-const getPetProfileLocalStorage = () => {
-  const stringifyPetProfile = localStorage.getItem('petProfile');
-
-  return stringifyPetProfile ? (JSON.parse(stringifyPetProfile) as PetProfile) : null;
-};
+import { zipgoLocalStorage } from '@/utils/localStorage';
 
 const PetProfileContext = createContext<PetProfileContext>({
-  petProfile: getPetProfileLocalStorage(),
+  petProfile: zipgoLocalStorage.getPetProfile(),
   updatePetProfile() {},
   resetPetProfile() {},
   inScope: false,
@@ -35,16 +30,16 @@ const PetProfileProvider = (props: PropsWithChildren<PetProfileProviderProps>) =
 
   const updatePetProfileLocalStorage = (petProfile: PetProfile) => {
     setPetProfile(petProfile);
-    localStorage.setItem('petProfile', JSON.stringify(petProfile));
+    zipgoLocalStorage.setPetProfile(petProfile);
   };
 
   const resetPetProfileLocalStorage = () => {
     setPetProfile(null);
-    localStorage.removeItem('petProfile');
+    zipgoLocalStorage.removePetProfile();
   };
 
   useEffect(() => {
-    setPetProfile(getPetProfileLocalStorage());
+    setPetProfile(zipgoLocalStorage.getPetProfile());
   }, []);
 
   const memoizedValue = useMemo(

--- a/frontend/src/context/petProfile/PetProfileContext.tsx
+++ b/frontend/src/context/petProfile/PetProfileContext.tsx
@@ -1,6 +1,5 @@
 import { createContext, PropsWithChildren, useEffect, useMemo, useState } from 'react';
 
-import useContextInScope from '@/hooks/@common/useContextInScope';
 import { PetProfile } from '@/types/petProfile/client';
 
 const getPetProfileLocalStorage = () => {
@@ -18,7 +17,7 @@ const PetProfileContext = createContext<PetProfileContext>({
 
 PetProfileContext.displayName = 'PetProfile';
 
-export const usePetProfile = () => useContextInScope(PetProfileContext);
+export const usePetProfile = () => useContext(PetProfileContext);
 
 interface PetProfileContext {
   petProfile: PetProfile | null;

--- a/frontend/src/hooks/auth.ts
+++ b/frontend/src/hooks/auth.ts
@@ -1,5 +1,4 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
 
 import { User } from '@/types/auth/client';
 import { PetProfile } from '@/types/petProfile/client';
@@ -31,23 +30,4 @@ export const useAuth = () => {
   };
 
   return { isLoggedIn, loginZipgo, logout };
-};
-
-export const useUser = () => {
-  const accessToken = localStorage.getItem('auth');
-  const userData = localStorage.getItem('userInfo');
-  const petProfileData = localStorage.getItem('petProfile');
-
-  const [userInfo, setUserInfo] = useState<User | null>(null);
-  const [petProfile, setPetProfile] = useState<PetProfile | null>(null);
-
-  useEffect(() => {
-    const parsedUserInfo = userData ? (JSON.parse(userData) as User) : null;
-    const parsedPetProfile = petProfileData ? (JSON.parse(petProfileData) as PetProfile) : null;
-
-    setUserInfo(parsedUserInfo);
-    setPetProfile(parsedPetProfile);
-  }, [userData, accessToken]);
-
-  return { userInfo, petProfile, setUserInfo, accessToken };
 };

--- a/frontend/src/hooks/auth.ts
+++ b/frontend/src/hooks/auth.ts
@@ -1,7 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 
-import { User } from '@/types/auth/client';
-import { PetProfile } from '@/types/petProfile/client';
+import { zipgoLocalStorage } from '@/utils/localStorage';
 
 import { useAuthMutation, useAuthQuery } from './query/auth';
 
@@ -20,9 +19,7 @@ export const useAuth = () => {
     const isLogout = confirm('로그아웃하시겠어요?');
 
     if (isLogout) {
-      localStorage.removeItem('auth');
-      localStorage.removeItem('userInfo');
-      localStorage.removeItem('petProfile');
+      zipgoLocalStorage.clearAuth();
 
       /** @todo 추후 api 추가 후 query hook으로 변경 */
       queryClient.invalidateQueries([QUERY_KEY.authenticateUser]);

--- a/frontend/src/hooks/query/auth.ts
+++ b/frontend/src/hooks/query/auth.ts
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { authenticateUser, loginZipgoAuth, logoutKaKaoAuth } from '@/apis/auth';
 import { routerPath } from '@/router/routes';
+import { zipgoLocalStorage } from '@/utils/localStorage';
 
 const QUERY_KEY = { authenticateUser: 'authenticateUser' };
 
@@ -26,8 +27,8 @@ export const useAuthMutation = () => {
   const { mutate: loginZipgo, ...loginRestMutation } = useMutation({
     mutationFn: loginZipgoAuth,
     onSuccess({ accessToken, authResponse }) {
-      localStorage.setItem('auth', accessToken);
-      localStorage.setItem('userInfo', JSON.stringify(authResponse));
+      zipgoLocalStorage.setTokens({ accessToken });
+      zipgoLocalStorage.setUserInfo(authResponse);
 
       queryClient.invalidateQueries([QUERY_KEY.authenticateUser]);
 

--- a/frontend/src/pages/PetProfile/PetProfileEdition/PetProfileEditionContent.tsx
+++ b/frontend/src/pages/PetProfile/PetProfileEdition/PetProfileEditionContent.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useEffect, useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 

--- a/frontend/src/pages/PetProfile/PetProfileEdition/PetProfileEditionContent.tsx
+++ b/frontend/src/pages/PetProfile/PetProfileEdition/PetProfileEditionContent.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/hooks/query/petProfile';
 import { PATH, routerPath } from '@/router/routes';
 import { PetSize } from '@/types/petProfile/client';
+import { zipgoLocalStorage } from '@/utils/localStorage';
 
 const PetProfileEditionContent = () => {
   const navigate = useNavigate();
@@ -49,9 +50,9 @@ const PetProfileEditionContent = () => {
   const onClickRemoveButton = (petId: number) => {
     confirm('정말 삭제하시겠어요?') &&
       removePetMutation.removePet({ petId }).then(() => {
-        const userInfo = JSON.parse(localStorage.getItem('userInfo')!);
+        const userInfo = zipgoLocalStorage.getUserInfo({ required: true });
 
-        localStorage.setItem('userInfo', JSON.stringify({ ...userInfo, hasPet: false }));
+        zipgoLocalStorage.setUserInfo({ ...userInfo, hasPet: false });
 
         resetPetProfile();
 

--- a/frontend/src/pages/PetProfile/PetProfileImageAdditionContent.tsx
+++ b/frontend/src/pages/PetProfile/PetProfileImageAdditionContent.tsx
@@ -10,6 +10,7 @@ import { useAddPetProfileMutation, useBreedListQuery } from '@/hooks/query/petPr
 import { routerPath } from '@/router/routes';
 import { PetProfile, PetProfileOutletContextProps } from '@/types/petProfile/client';
 import { getTopicParticle } from '@/utils/getTopicParticle';
+import { zipgoLocalStorage } from '@/utils/localStorage';
 
 const PetProfileImageAdditionContent = () => {
   const navigate = useNavigate();
@@ -27,7 +28,7 @@ const PetProfileImageAdditionContent = () => {
     addPetProfileMutation
       .addPetProfile(petProfile)
       .then(async res => {
-        const userInfo = JSON.parse(localStorage.getItem('userInfo')!);
+        const userInfo = zipgoLocalStorage.getUserInfo({ required: true });
 
         const userPetBreed = breedList?.find(breed => breed.name === petProfile.breed);
         const petProfileWithId = {
@@ -37,8 +38,7 @@ const PetProfileImageAdditionContent = () => {
         } as PetProfile;
 
         updatePetProfile(petProfileWithId); // 헤더 유저 프로필 정보 업데이트
-
-        localStorage.setItem('userInfo', JSON.stringify({ ...userInfo, hasPet: true }));
+        zipgoLocalStorage.setUserInfo({ ...userInfo, hasPet: true });
 
         alert('반려동물 정보 등록이 완료되었습니다.');
       })

--- a/frontend/src/types/auth/client.ts
+++ b/frontend/src/types/auth/client.ts
@@ -1,16 +1,7 @@
 interface User {
   profileImgUrl: string;
   name: string;
+  hasPet: boolean;
 }
 
-interface PetProfile {
-  name: string;
-  age: number;
-  breed: string;
-  gender: string;
-  weight: number;
-  imageUrl: string;
-  id: number;
-}
-
-export type { PetProfile, User };
+export type { User };

--- a/frontend/src/types/auth/client.ts
+++ b/frontend/src/types/auth/client.ts
@@ -1,7 +1,11 @@
+interface Tokens {
+  accessToken: string;
+}
+
 interface User {
   profileImgUrl: string;
   name: string;
   hasPet: boolean;
 }
 
-export type { User };
+export type { Tokens, User };

--- a/frontend/src/types/auth/remote.ts
+++ b/frontend/src/types/auth/remote.ts
@@ -1,4 +1,7 @@
 /** @description kakao REST API error response - kauth.kakao.com */
+
+import { User } from './client';
+
 /** @see https://developers.kakao.com/docs/latest/ko/reference/rest-api-reference#response-format */
 export interface KakaoAuthError {
   error: string;
@@ -18,11 +21,7 @@ export interface LoginZipgoAuthReq {
 
 export interface LoginZipgoAuthRes {
   accessToken: string;
-  authResponse: {
-    name: string;
-    profileImgUrl: string;
-    hasPet: boolean;
-  };
+  authResponse: User;
 }
 
 export interface LoginKakaoAuthReq {

--- a/frontend/src/types/petProfile/client.ts
+++ b/frontend/src/types/petProfile/client.ts
@@ -5,7 +5,7 @@ type PetProfile = {
   name: string;
   age: number;
   breed: Breed['name'];
-  petSize: PetSize | undefined;
+  petSize?: PetSize;
   gender: Gender;
   weight: number;
   imageUrl: string;

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -1,0 +1,109 @@
+import { User } from '@/types/auth/client';
+import { PetProfile } from '@/types/petProfile/client';
+
+import { invariantOf } from './invariantOf';
+
+interface LocalStorageKit {
+  <T>(key: STORAGE_KEY): InvariantOf<KitComponents<T>>;
+}
+
+interface KitComponents<T> {
+  getItem: GetLocalStorageItem<T>;
+  setItem: SetLocalStorageItem<T>;
+  removeItem: RemoveLocalStorageItem;
+}
+
+interface GetLocalStorageItem<T> {
+  <R extends boolean>(options?: GetItemOptions<T, R>): ReturnType<typeof getItem<T, R>>;
+}
+
+interface SetLocalStorageItem<T> {
+  (item: T): ReturnType<typeof setItem<T>>;
+}
+
+interface RemoveLocalStorageItem {
+  (): ReturnType<typeof removeItem>;
+}
+
+type GetItemOptions<T, R extends boolean> = {
+  defaultValue?: T | null;
+  required?: R;
+};
+
+type GetItemResult<T, R extends boolean> = R extends true ? T : T | null;
+
+type Tokens = {
+  accessToken: string;
+};
+
+type STORAGE_KEY = keyof typeof STORAGE_KEY;
+
+export const STORAGE_KEY = {
+  tokens: 'tokens',
+  userInfo: 'userInfo',
+  petProfile: 'petProfile',
+} as const;
+
+export const localStorageKit: LocalStorageKit = <T>(key: STORAGE_KEY) =>
+  invariantOf({
+    getItem: <R extends boolean>(options?: GetItemOptions<T, R>) => getItem<T, R>(key, options),
+    setItem: (item: T) => setItem(key, item),
+    removeItem: () => removeItem(key),
+  });
+
+const getItem = <T = unknown, R extends boolean = false>(
+  key: STORAGE_KEY,
+  options?: GetItemOptions<T, R>,
+): GetItemResult<T, R> => {
+  const value = localStorage.getItem(key);
+  const { defaultValue = null, required } = options || { defaultValue: null };
+
+  if (required && !value) {
+    throw new Error('Item does not exist in local storage.');
+  }
+
+  return value ? JSON.parse(value) : defaultValue;
+};
+
+const setItem = <T = unknown>(key: STORAGE_KEY, item: T) => {
+  try {
+    const stringifiedItem = JSON.stringify(item);
+
+    localStorage.setItem(key, stringifiedItem);
+  } catch (error) {
+    throw new Error('Fail to set item. Enable the localStorage or check localStorage quota.');
+  }
+};
+
+const removeItem = (key: STORAGE_KEY) => localStorage.removeItem(key);
+
+const clearAuth = () => {
+  localStorageKit(STORAGE_KEY.tokens).removeItem();
+  localStorageKit(STORAGE_KEY.userInfo).removeItem();
+  localStorageKit(STORAGE_KEY.petProfile).removeItem();
+};
+
+const getTokens = localStorageKit<Tokens>(STORAGE_KEY.tokens).getItem;
+
+const setTokens = localStorageKit<Tokens>(STORAGE_KEY.tokens).setItem;
+
+const getUserInfo = localStorageKit<User>(STORAGE_KEY.userInfo).getItem;
+
+const setUserInfo = localStorageKit<User>(STORAGE_KEY.userInfo).setItem;
+
+const getPetProfile = localStorageKit<PetProfile>(STORAGE_KEY.petProfile).getItem;
+
+const setPetProfile = localStorageKit<PetProfile>(STORAGE_KEY.petProfile).setItem;
+
+const removePetProfile = localStorageKit<PetProfile>(STORAGE_KEY.petProfile).removeItem;
+
+export const zipgoLocalStorage = {
+  clearAuth,
+  getTokens,
+  setTokens,
+  getUserInfo,
+  setUserInfo,
+  getPetProfile,
+  setPetProfile,
+  removePetProfile,
+};

--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -1,4 +1,4 @@
-import { User } from '@/types/auth/client';
+import { Tokens, User } from '@/types/auth/client';
 import { PetProfile } from '@/types/petProfile/client';
 
 import { invariantOf } from './invariantOf';
@@ -31,10 +31,6 @@ type GetItemOptions<T, R extends boolean> = {
 };
 
 type GetItemResult<T, R extends boolean> = R extends true ? T : T | null;
-
-type Tokens = {
-  accessToken: string;
-};
 
 type STORAGE_KEY = keyof typeof STORAGE_KEY;
 


### PR DESCRIPTION
# 📄 Summary
- 기존 유저 정보 확인 api가 사용 가능해짐에 따라 계획했던 "토큰으로 로그인 여부 확인하기"의 변경을 보류했습니다!
- token 관련 localStorage key를 `auth` > `tokens`로 변경했습니다! ( 추후 `refreshToken` 추가를 염두하여 객체로 구현했습니다)

## Tokens
```tsx
interface Tokens {
  accessToken: string
}
```

## localStorageKit
```tsx
const STORAGE_KEY = {
  tokens: 'tokens',
  userInfo: 'userInfo',
  petProfile: 'petProfile',
} as const;

const getTokens = localStorageKit<Tokens>(STORAGE_KEY.tokens).getItem;
const setTokens = localStorageKit<Tokens>(STORAGE_KEY.tokens).setItem;

const tokens = getTokens() // Tokens || null

const { accessToken } = getTokens({ required: true }) // Tokens

const setTokens({ accessToken })
```

### GetItemOptions
defaultValue : `unkown` | default : `null`
required : `boolean` | default : `false`

## zipgoLocalStorage
```tsx
const userInfo = zipgoLocalStorage.getUserInfo() // UserInfo || null

const { name } = zipgoLocalStorage.getUserInfo({ required: true }) // UserInfo
```

```tsx
const {
  clearAuth,
  getTokens,
  setTokens,
  getUserInfo,
  setUserInfo,
  getPetProfile,
  setPetProfile,
  removePetProfile,
} = zipgoLocalStorage

```


## 🙋🏻 More
>  - close #363 
