### PR TITLE
feat: 폼 컴포넌트 테스트 추가 및 리뷰 관련 코드 리팩터링

### DIFF
--- a/frontend/src/components/PetProfile/PetProfileEditionForm/PetProfileEditionForm.stories.tsx
+++ b/frontend/src/components/PetProfile/PetProfileEditionForm/PetProfileEditionForm.stories.tsx
@@ -82,3 +82,53 @@ export const InvalidWeight: Story = {
     expect(weightErrorMessage).toBeVisible();
   },
 };
+
+export const ValidForm: Story = {
+  args: [],
+
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() => {
+      const element = screen.getByLabelText('이름 입력');
+      expect(element).toBeInTheDocument();
+    });
+
+    const petNameInput = canvas.getByLabelText('이름 입력');
+    await userEvent.type(petNameInput, '{backspace}{backspace}', { delay: 100 });
+    await userEvent.type(petNameInput, '멍멍이', { delay: 100 });
+
+    const petWeightInput = canvas.getByLabelText('몸무게 입력');
+    await userEvent.type(petWeightInput, '{backspace}{backspace}{backspace}', { delay: 100 });
+    await userEvent.type(petWeightInput, '35.5', { delay: 100 });
+
+    const editButton = canvas.getByText('수정');
+
+    expect(editButton).toBeEnabled();
+  },
+};
+
+export const InvalidForm: Story = {
+  args: [],
+
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() => {
+      const element = screen.getByLabelText('이름 입력');
+      expect(element).toBeInTheDocument();
+    });
+
+    const petNameInput = canvas.getByLabelText('이름 입력');
+    await userEvent.type(petNameInput, '{backspace}{backspace}', { delay: 100 });
+    await userEvent.type(petNameInput, '멍멍이🐾', { delay: 100 });
+
+    const petWeightInput = canvas.getByLabelText('몸무게 입력');
+    await userEvent.type(petWeightInput, '{backspace}{backspace}{backspace}', { delay: 100 });
+    await userEvent.type(petWeightInput, '107', { delay: 100 });
+
+    const editButton = canvas.getByText('수정');
+
+    expect(editButton).toBeDisabled();
+  },
+};

--- a/frontend/src/components/PetProfile/PetProfileEditionForm/PetProfileEditionForm.stories.tsx
+++ b/frontend/src/components/PetProfile/PetProfileEditionForm/PetProfileEditionForm.stories.tsx
@@ -4,7 +4,6 @@ import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { reactRouterParameters } from 'storybook-addon-react-router-v6';
-import { styled } from 'styled-components';
 
 import PetProfileProvider from '../../../context/petProfile/PetProfileContext';
 import PetProfileEditionForm from './PetProfileEditionForm';

--- a/frontend/src/components/Review/ReviewForm/ReviewForm.stories.tsx
+++ b/frontend/src/components/Review/ReviewForm/ReviewForm.stories.tsx
@@ -10,7 +10,6 @@ import ReviewForm from './ReviewForm';
 const meta = {
   title: 'Review/ReviewForm',
   component: ReviewForm,
-  tags: ['autodocs'],
   decorators: [Story => <Story />],
 } satisfies Meta<typeof ReviewForm>;
 
@@ -69,5 +68,128 @@ export const InvalidForm: Story = {
     const completeButton = canvas.getByText('작성 완료');
 
     expect(completeButton).toBeDisabled();
+  },
+};
+
+export const SingleSelectionTestForTastePreference: Story = {
+  args: {
+    petFoodId: 1,
+    rating: 5,
+  },
+
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() => {
+      const element = screen.getByText('기호성');
+      expect(element).toBeInTheDocument();
+    });
+
+    const tastePreferences = canvas.getAllByTestId('tastePreference');
+    const checkedTastePreference = tastePreferences[1];
+
+    await userEvent.click(checkedTastePreference, { delay: 100 });
+
+    expect(checkedTastePreference).toHaveAttribute('aria-checked', 'true');
+
+    tastePreferences.forEach(tastePreference => {
+      if (tastePreference !== checkedTastePreference) {
+        expect(tastePreference).toHaveAttribute('aria-checked', 'false');
+      }
+    });
+  },
+};
+
+export const SingleSelectionTestForStoolCondition: Story = {
+  args: {
+    petFoodId: 1,
+    rating: 5,
+  },
+
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() => {
+      const element = screen.getByText('대변 상태');
+      expect(element).toBeInTheDocument();
+    });
+
+    const stoolConditions = canvas.getAllByTestId('stoolCondition');
+    const checkedStoolCondition = stoolConditions[1];
+
+    await userEvent.click(checkedStoolCondition, { delay: 100 });
+
+    expect(checkedStoolCondition).toHaveAttribute('aria-checked', 'true');
+
+    stoolConditions.forEach(stoolCondition => {
+      if (stoolCondition !== checkedStoolCondition) {
+        expect(stoolCondition).toHaveAttribute('aria-checked', 'false');
+      }
+    });
+  },
+};
+
+export const MultipleSelectionTestForAdverseReaction: Story = {
+  args: {
+    petFoodId: 1,
+    rating: 5,
+  },
+
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() => {
+      const element = screen.getByText('이상 반응');
+      expect(element).toBeInTheDocument();
+    });
+
+    const adverseReactions = canvas.getAllByTestId('adverseReaction');
+
+    await userEvent.click(adverseReactions[1], { delay: 100 });
+    await userEvent.click(adverseReactions[2], { delay: 100 });
+
+    const checkedAdverseReactions = [adverseReactions[1], adverseReactions[2]];
+
+    adverseReactions.forEach(adverseReaction => {
+      if (checkedAdverseReactions.includes(adverseReaction)) {
+        expect(adverseReaction).toHaveAttribute('aria-checked', 'true');
+      }
+
+      if (!checkedAdverseReactions.includes(adverseReaction)) {
+        expect(adverseReaction).toHaveAttribute('aria-checked', 'false');
+      }
+    });
+  },
+};
+
+export const NoneButtonDeselectOthersTestForAdverseReaction: Story = {
+  args: {
+    petFoodId: 1,
+    rating: 5,
+  },
+
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() => {
+      const element = screen.getByText('이상 반응');
+      expect(element).toBeInTheDocument();
+    });
+
+    const adverseReactions = canvas.getAllByTestId('adverseReaction');
+    const noneAdverseReaction = adverseReactions[0];
+
+    await userEvent.click(adverseReactions[1], { delay: 100 });
+    await userEvent.click(noneAdverseReaction, { delay: 100 });
+
+    adverseReactions.forEach(adverseReaction => {
+      if (noneAdverseReaction === adverseReaction) {
+        expect(adverseReaction).toHaveAttribute('aria-checked', 'true');
+      }
+
+      if (noneAdverseReaction !== adverseReaction) {
+        expect(adverseReaction).toHaveAttribute('aria-checked', 'false');
+      }
+    });
   },
 };

--- a/frontend/src/components/Review/ReviewForm/ReviewForm.stories.tsx
+++ b/frontend/src/components/Review/ReviewForm/ReviewForm.stories.tsx
@@ -1,6 +1,10 @@
+import { expect } from '@storybook/jest';
 import type { Meta, StoryObj } from '@storybook/react';
+import { screen, waitFor, within } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
+import { COMMENT_LIMIT } from '../../../constants/review';
 import ReviewForm from './ReviewForm';
 
 const meta = {
@@ -17,5 +21,29 @@ export const Basic: Story = {
   args: {
     petFoodId: 1,
     rating: 5,
+  },
+};
+
+export const InvalidForm: Story = {
+  args: {
+    petFoodId: 1,
+    rating: 5,
+  },
+
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() => {
+      const textBox = screen.getByRole('textbox');
+      expect(textBox).toBeInTheDocument();
+    });
+
+    const commentTextarea = canvas.getByRole('textbox');
+    const longText = new Array(COMMENT_LIMIT + 1).fill(1).join('');
+    await userEvent.type(commentTextarea, longText, { delay: 5 });
+
+    const completeButton = canvas.getByText('작성 완료');
+
+    expect(completeButton).toBeDisabled();
   },
 };

--- a/frontend/src/components/Review/ReviewForm/ReviewForm.stories.tsx
+++ b/frontend/src/components/Review/ReviewForm/ReviewForm.stories.tsx
@@ -24,6 +24,30 @@ export const Basic: Story = {
   },
 };
 
+export const ValidForm: Story = {
+  args: {
+    petFoodId: 1,
+    rating: 5,
+  },
+
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() => {
+      const textBox = screen.getByRole('textbox');
+      expect(textBox).toBeInTheDocument();
+    });
+
+    const commentTextarea = canvas.getByRole('textbox');
+    const validText = '저희집 에디가 너무 잘먹어요^^';
+    await userEvent.type(commentTextarea, validText, { delay: 100 });
+
+    const completeButton = canvas.getByText('작성 완료');
+
+    expect(completeButton).toBeEnabled();
+  },
+};
+
 export const InvalidForm: Story = {
   args: {
     petFoodId: 1,

--- a/frontend/src/components/Review/ReviewForm/ReviewForm.tsx
+++ b/frontend/src/components/Review/ReviewForm/ReviewForm.tsx
@@ -1,7 +1,12 @@
 import { styled } from 'styled-components';
 
 import Label from '@/components/@common/Label/Label';
-import { ADVERSE_REACTIONS, STOOL_CONDITIONS, TASTE_PREFERENCES } from '@/constants/review';
+import {
+  ADVERSE_REACTIONS,
+  REVIEW_ERROR_MESSAGE,
+  STOOL_CONDITIONS,
+  TASTE_PREFERENCES,
+} from '@/constants/review';
 import { ACTION_TYPES, useReviewForm } from '@/hooks/review/useReviewForm';
 
 interface ReviewFormProps {
@@ -14,7 +19,7 @@ interface ReviewFormProps {
 const ReviewForm = (reviewFormProps: ReviewFormProps) => {
   const { petFoodId, rating, isEditMode = false, reviewId = -1 } = reviewFormProps;
 
-  const { review, reviewDispatch, onSubmitReview } = useReviewForm({
+  const { review, reviewDispatch, onSubmitReview, isValidComment } = useReviewForm({
     petFoodId,
     rating,
     isEditMode,
@@ -89,12 +94,18 @@ const ReviewForm = (reviewFormProps: ReviewFormProps) => {
           id="comment"
           placeholder="제품에 대한 솔직한 리뷰를 남겨주세요. (선택)"
           value={review.comment}
+          $isValid={isValidComment}
           onChange={e => {
             reviewDispatch({ type: ACTION_TYPES.SET_COMMENT, comment: e.target.value });
           }}
         />
+        <ErrorCaption aria-live="assertive">
+          {isValidComment ? '' : REVIEW_ERROR_MESSAGE.INVALID_COMMENT}
+        </ErrorCaption>
       </DetailReviewContainer>
-      <SubmitButton type="submit">작성 완료</SubmitButton>
+      <SubmitButton type="submit" disabled={!isValidComment}>
+        작성 완료
+      </SubmitButton>
     </ReviewFormContainer>
   );
 };
@@ -127,12 +138,11 @@ const LabelContainer = styled.div`
   gap: 0.8rem;
 `;
 
-const DetailReviewText = styled.textarea`
+const DetailReviewText = styled.textarea<{ $isValid: boolean }>`
   resize: none;
 
   width: 100%;
   min-height: 12rem;
-  margin-bottom: 9rem;
   padding: 1.2rem;
 
   font-size: 1.6rem;
@@ -143,9 +153,10 @@ const DetailReviewText = styled.textarea`
   border-radius: 8px;
 
   &:focus {
-    border-color: #d0e6f9;
+    border-color: ${({ $isValid }) => ($isValid ? '#d0e6f9' : '#EFA9AF')};
     outline: none;
-    box-shadow: 0 0 0 3px rgb(141 201 255 / 40%);
+    box-shadow: ${({ $isValid }) =>
+      $isValid ? '0 0 0 3px rgb(141 201 255 / 40%)' : '0 0 0 3px rgb(231 56 70 / 40%)'};
   }
 `;
 
@@ -169,4 +180,22 @@ const SubmitButton = styled.button`
   letter-spacing: 0.2px;
 
   background-color: ${({ theme }) => theme.color.primary};
+
+  &:disabled {
+    cursor: not-allowed;
+
+    background-color: ${({ theme }) => theme.color.grey300};
+  }
+`;
+
+const ErrorCaption = styled.p`
+  min-height: 1.7rem;
+  margin-top: 1rem;
+  margin-bottom: 10rem;
+
+  font-size: 1.3rem;
+  font-weight: 500;
+  line-height: 1.7rem;
+  color: ${({ theme }) => theme.color.warning};
+  letter-spacing: -0.5px;
 `;

--- a/frontend/src/components/Review/ReviewForm/ReviewForm.tsx
+++ b/frontend/src/components/Review/ReviewForm/ReviewForm.tsx
@@ -1,16 +1,8 @@
-import { FormEvent, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import Label from '@/components/@common/Label/Label';
 import { ADVERSE_REACTIONS, STOOL_CONDITIONS, TASTE_PREFERENCES } from '@/constants/review';
-import {
-  useAddReviewMutation,
-  useEditReviewMutation,
-  useReviewItemQuery,
-} from '@/hooks/query/review';
 import { ACTION_TYPES, useReviewForm } from '@/hooks/review/useReviewForm';
-import { routerPath } from '@/router/routes';
 
 interface ReviewFormProps {
   petFoodId: number;
@@ -21,51 +13,13 @@ interface ReviewFormProps {
 
 const ReviewForm = (reviewFormProps: ReviewFormProps) => {
   const { petFoodId, rating, isEditMode = false, reviewId = -1 } = reviewFormProps;
-  const { reviewItem } = useReviewItemQuery({ reviewId });
-  const { addReviewMutation } = useAddReviewMutation();
-  const { editReviewMutation } = useEditReviewMutation();
-  const { review, reviewDispatch } = useReviewForm({ petFoodId, rating });
 
-  const navigate = useNavigate();
-
-  const onSubmitReview = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    if (isEditMode && reviewItem) {
-      editReviewMutation.editReview({ reviewId, ...review }).then(() => {
-        alert('리뷰 수정이 완료되었습니다.');
-        navigate(routerPath.foodDetail({ petFoodId }));
-      });
-
-      return;
-    }
-
-    addReviewMutation.addReview(review).then(() => {
-      alert('리뷰 작성이 완료되었습니다.');
-      navigate(routerPath.foodDetail({ petFoodId }));
-    });
-  };
-
-  useEffect(() => {
-    if (isEditMode && reviewItem) {
-      reviewDispatch({
-        type: ACTION_TYPES.SET_TASTE_PREFERENCE,
-        tastePreference: reviewItem.tastePreference,
-      });
-
-      reviewDispatch({
-        type: ACTION_TYPES.SET_STOOL_CONDITION,
-        stoolCondition: reviewItem.stoolCondition,
-      });
-
-      reviewDispatch({
-        type: ACTION_TYPES.SET_ADVERSE_REACTIONS_DEFAULT,
-        adverseReactions: reviewItem.adverseReactions,
-      });
-
-      reviewDispatch({ type: ACTION_TYPES.SET_COMMENT, comment: reviewItem.comment });
-    }
-  }, [isEditMode, reviewItem, reviewDispatch]);
+  const { review, reviewDispatch, onSubmitReview } = useReviewForm({
+    petFoodId,
+    rating,
+    isEditMode,
+    reviewId,
+  });
 
   return (
     <ReviewFormContainer onSubmit={onSubmitReview}>

--- a/frontend/src/components/Review/ReviewForm/ReviewForm.tsx
+++ b/frontend/src/components/Review/ReviewForm/ReviewForm.tsx
@@ -33,6 +33,7 @@ const ReviewForm = (reviewFormProps: ReviewFormProps) => {
         <LabelContainer role="radiogroup" id="tastePreference">
           {TASTE_PREFERENCES.map(text => (
             <Label
+              data-testid="tastePreference"
               role="radio"
               key={text}
               text={text}
@@ -53,6 +54,7 @@ const ReviewForm = (reviewFormProps: ReviewFormProps) => {
         <LabelContainer role="radiogroup" id="stoolCondition">
           {STOOL_CONDITIONS.map(text => (
             <Label
+              data-testid="stoolCondition"
               role="radio"
               key={text}
               text={text}
@@ -73,6 +75,7 @@ const ReviewForm = (reviewFormProps: ReviewFormProps) => {
         <LabelContainer id="adverseReactions">
           {ADVERSE_REACTIONS.map(text => (
             <Label
+              data-testid="adverseReaction"
               role="checkbox"
               key={text}
               text={text}

--- a/frontend/src/components/Review/ReviewItem/ReveiwItem.stories.tsx
+++ b/frontend/src/components/Review/ReviewItem/ReveiwItem.stories.tsx
@@ -31,7 +31,6 @@ type Story = StoryObj<typeof ReviewItem>;
 export const Basic: Story = {
   args: {
     id: 1,
-    reviewerName: '에디',
     rating: 4,
     date: '2023-05-26',
     comment:
@@ -39,13 +38,28 @@ export const Basic: Story = {
     tastePreference: '정말 잘 먹어요',
     stoolCondition: '촉촉 말랑해요',
     adverseReactions: [],
+    petProfile: {
+      id: 1,
+      name: '하이브리드 샘이솟아 리오레이비',
+      profileUrl:
+        'https://velog.velcdn.com/images/chex/post/4d4a31d6-a3d9-4acd-8065-2486360eb8d2/image.JPG',
+      writtenAge: 7,
+      writtenWeight: 100,
+      breed: {
+        name: '믹스견',
+        size: { name: '대형견' },
+      },
+    },
+    helpfulReaction: {
+      count: 5,
+      reacted: true,
+    },
   },
 };
 
 export const LongComment: Story = {
   args: {
-    id: 1,
-    reviewerName: '민무',
+    id: 2,
     rating: 5,
     date: '2023-06-26',
     comment:
@@ -53,13 +67,27 @@ export const LongComment: Story = {
     tastePreference: '정말 잘 먹어요',
     stoolCondition: '촉촉 말랑해요',
     adverseReactions: ['눈물이 나요', '발을 핥아요'],
+    petProfile: {
+      id: 1,
+      name: '개똥이',
+      profileUrl: '',
+      writtenAge: 3,
+      writtenWeight: 10,
+      breed: {
+        name: '스피츠',
+        size: { name: '중형견' },
+      },
+    },
+    helpfulReaction: {
+      count: 5,
+      reacted: true,
+    },
   },
 };
 
 export const ShortComment: Story = {
   args: {
     id: 1,
-    reviewerName: '가비',
     rating: 5,
     date: '2023-07-26',
     comment:
@@ -67,5 +95,21 @@ export const ShortComment: Story = {
     tastePreference: '정말 잘 먹어요',
     stoolCondition: '딱딱해요',
     adverseReactions: [],
+    petProfile: {
+      id: 3,
+      name: '아루',
+      profileUrl:
+        'https://velog.velcdn.com/images/chex/post/1b521233-131a-4b6e-bcf8-ba7eb8395160/image.jpeg',
+      writtenAge: 2,
+      writtenWeight: 3,
+      breed: {
+        name: '몰티즈',
+        size: { name: '소형견' },
+      },
+    },
+    helpfulReaction: {
+      count: 5,
+      reacted: true,
+    },
   },
 };

--- a/frontend/src/components/Review/ReviewItem/ReviewItem.tsx
+++ b/frontend/src/components/Review/ReviewItem/ReviewItem.tsx
@@ -114,7 +114,7 @@ const ReviewItem = (reviewItemProps: ReviewItemProps) => {
         </Reaction>
         <Reaction key={REACTIONS.ADVERSE_REACTION}>
           <ReactionTitle>{REACTIONS.ADVERSE_REACTION}</ReactionTitle>
-          <ReactionContent>{adverseReactions.join(', ') || '없음'}</ReactionContent>
+          <ReactionContent>{adverseReactions.join(', ') || REACTIONS.NOTHING}</ReactionContent>
         </Reaction>
       </Reactions>
       <Comment isExpanded={isCommentExpanded}>{comment}</Comment>

--- a/frontend/src/components/Review/ReviewItem/ReviewItem.tsx
+++ b/frontend/src/components/Review/ReviewItem/ReviewItem.tsx
@@ -62,7 +62,7 @@ const ReviewItem = (reviewItemProps: ReviewItemProps) => {
   };
 
   const onClickRemoveButton = () => {
-    confirm('정말 삭제하시곘어요?') && removeReviewMutation.removeReview({ reviewId, petFoodId });
+    confirm('정말 삭제하시겠어요?') && removeReviewMutation.removeReview({ reviewId, petFoodId });
   };
 
   const onClickHelpfulButton = () => {

--- a/frontend/src/components/Review/ReviewItem/ReviewItem.tsx
+++ b/frontend/src/components/Review/ReviewItem/ReviewItem.tsx
@@ -114,7 +114,7 @@ const ReviewItem = (reviewItemProps: ReviewItemProps) => {
         </Reaction>
         <Reaction key={REACTIONS.ADVERSE_REACTION}>
           <ReactionTitle>{REACTIONS.ADVERSE_REACTION}</ReactionTitle>
-          <ReactionContent>{adverseReactions.join(', ') || REACTIONS.NOTHING}</ReactionContent>
+          <ReactionContent>{adverseReactions.join(', ') || REACTIONS.NONE}</ReactionContent>
         </Reaction>
       </Reactions>
       <Comment isExpanded={isCommentExpanded}>{comment}</Comment>

--- a/frontend/src/components/Review/ReviewItem/ReviewItem.tsx
+++ b/frontend/src/components/Review/ReviewItem/ReviewItem.tsx
@@ -114,7 +114,7 @@ const ReviewItem = (reviewItemProps: ReviewItemProps) => {
         </Reaction>
         <Reaction key={REACTIONS.ADVERSE_REACTION}>
           <ReactionTitle>{REACTIONS.ADVERSE_REACTION}</ReactionTitle>
-          <ReactionContent>{adverseReactions.join(', ')}</ReactionContent>
+          <ReactionContent>{adverseReactions.join(', ') || '없음'}</ReactionContent>
         </Reaction>
       </Reactions>
       <Comment isExpanded={isCommentExpanded}>{comment}</Comment>

--- a/frontend/src/constants/review.ts
+++ b/frontend/src/constants/review.ts
@@ -47,3 +47,8 @@ export const SATISFACTION_MESSAGES = [
   '정말 좋았어요!',
   '만족도 최고예요!🔥',
 ] as const;
+
+export const COMMENT_LIMIT = 500;
+export const REVIEW_ERROR_MESSAGE = {
+  INVALID_COMMENT: '리뷰는 500자 이하로 작성해주세요!',
+} as const;

--- a/frontend/src/constants/review.ts
+++ b/frontend/src/constants/review.ts
@@ -9,7 +9,7 @@ export const REACTIONS = {
   TASTE_PREFERENCE: '기호성',
   STOOL_CONDITION: '대변상태',
   ADVERSE_REACTION: '이상반응',
-  NOTHING: '없어요',
+  NONE: '없어요',
 } as const;
 
 export const COMMENT_VISIABLE_LINE_LIMIT = 180;

--- a/frontend/src/constants/review.ts
+++ b/frontend/src/constants/review.ts
@@ -48,7 +48,7 @@ export const SATISFACTION_MESSAGES = [
   '만족도 최고예요!🔥',
 ] as const;
 
-export const COMMENT_LIMIT = 500;
+export const COMMENT_LIMIT = 255;
 export const REVIEW_ERROR_MESSAGE = {
-  INVALID_COMMENT: '리뷰는 500자 이하로 작성해주세요!',
+  INVALID_COMMENT: `리뷰는 ${COMMENT_LIMIT}자 이하로 작성해주세요!`,
 } as const;

--- a/frontend/src/hooks/petProfile/usePetProfileEdition.ts
+++ b/frontend/src/hooks/petProfile/usePetProfileEdition.ts
@@ -64,8 +64,7 @@ export const usePetProfileEdition = () => {
       return { ...prev, weight: petWeight };
     });
 
-    if (isValidWeight(petWeight)) setIsValidWeightInput(true);
-    if (!isValidWeight(petWeight)) setIsValidWeightInput(false);
+    setIsValidWeightInput(isValidWeight(petWeight));
   };
 
   const onChangePetSize = (petSize: PetSize) => {

--- a/frontend/src/hooks/review/useReviewForm.ts
+++ b/frontend/src/hooks/review/useReviewForm.ts
@@ -1,7 +1,12 @@
 import { FormEvent, useEffect, useReducer } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { ADVERSE_REACTIONS, STOOL_CONDITIONS, TASTE_PREFERENCES } from '@/constants/review';
+import {
+  ADVERSE_REACTIONS,
+  COMMENT_LIMIT,
+  STOOL_CONDITIONS,
+  TASTE_PREFERENCES,
+} from '@/constants/review';
 import { routerPath } from '@/router/routes';
 import { AdverseReaction, StoolCondition, TastePreference } from '@/types/review/client';
 import { PostReviewReq } from '@/types/review/remote';
@@ -107,6 +112,8 @@ export const useReviewForm = (useReviewFormProps: UseReviewFormProps) => {
 
   const [review, reviewDispatch] = useReducer(reducer, reviewInitialState);
 
+  const isValidComment = review.comment.length <= COMMENT_LIMIT;
+
   const onSubmitReview = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -150,5 +157,6 @@ export const useReviewForm = (useReviewFormProps: UseReviewFormProps) => {
     review,
     reviewDispatch,
     onSubmitReview,
+    isValidComment,
   };
 };


### PR DESCRIPTION
## 📄 Summary
[5차 데모데이까지 진행할 테스트 목표](https://github.com/woowacourse-teams/2023-zipgo/wiki/%5BFE%5D-%ED%85%8C%EC%8A%A4%ED%8C%85-%EC%A0%84%EB%9E%B5-%EC%88%98%EB%A6%BD-%EB%B0%8F-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%9E%90%EB%8F%99%ED%99%94)에 따라 테스트 코드를 추가했습니당

https://github.com/woowacourse-teams/2023-zipgo/assets/24777828/350c369d-8c3c-478a-9cb2-8274d3c3cb82


### ✅ Tasks

### 5차 데모데이까지 진행해야하는 테스트 목록
- [x] PetProfileEditionForm 컴포넌트
  - [x] 유효하지 않은 반려동물 이름을 입력하면 에러메시지가 출력된다.
  - [x] 유효하지 않은 반려동물 몸무게를 입력하면 에러메시지가 출력된다.
  - [x] 유효한 데이터를 입력하면 수정 버튼이 활성화 된다.
  - [x] 유효하지 않은 데이터를 입력하면 수정 버튼이 비활성화 된다.
- [x] ReviewForm 컴포넌트
  - [x] 유효한 데이터를 입력하면 작성 완료 버튼이 활성화 된다.
  - [x] 유효하지 않은 데이터를 입력하면 작성 완료 버튼이 비활성화 된다.
  - [x] 기호성 버튼 클릭 시 해당 버튼만 선택 된다.
  - [x] 대변 상태 버튼 클릭 시 해당 버튼만 선택 된다.
  - [x] 이상 반응
    - [x] 없어요 버튼 클릭 시 다른 버튼은 선택 해제 된다.
    - [x] 없어요를 제외한 다른 버튼은 중복 선택이 가능하다.
  - [x] 상세한 후기
    - [x] 글자 범위를 초과하면 에러메시지가 출력된다.

### 기타
- [x] 리뷰 아이템 스토리북 에러 해결
- [x] 리뷰폼 코멘트 유효성 검사 로직 추가
- [x] 리뷰폼 onSubmitReview 로직 훅으로 분리 


## 🙋🏻 More
> 
리뷰 글자수 제한 500자로 했다가 백엔드쪽에서 막혀서 255자로 줄였습니다.
이거 어떤가요 넘 작을까요?

- close #385 
