### PR TITLE
fix: dev.zipgo.pet 로그인 시 에러나는 문제 해결

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,11 +4,11 @@
   "scripts": {
     "type-check": "tsc --noEmit",
     "type-check:watch": "yarn type-check --watch",
-    "start:dev": "cross-env NODE_ENV=development MSW=on webpack serve --config config/webpack.dev.js",
+    "start:dev": "cross-env NODE_ENV=development MSW=on STRICT_MODE=on webpack serve --config config/webpack.dev.js",
     "start:prod": "serve -s dist",
     "start:sb": "storybook dev -p 6006",
     "build:prod": "cross-env NODE_ENV=production webpack --progress --config config/webpack.prod.js",
-    "build:dev": "cross-env NODE_ENV=development webpack --progress --config config/webpack.dev.js",
+    "build:dev": "cross-env NODE_ENV=development STRICT_MODE=off webpack --progress --config config/webpack.dev.js",
     "build:sb": "sb build",
     "postinstall": "cd .. && husky install frontend/.husky && chmod +x frontend/.husky/*",
     "test-storybook": "test-storybook"

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -31,12 +31,14 @@ const errorFallback = ({ reset }: ErrorBoundaryValue) => (
   </button>
 );
 
-root.render(
-  <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <QueryBoundary errorFallback={errorFallback}>
-        <Router />
-      </QueryBoundary>
-    </QueryClientProvider>
-  </React.StrictMode>,
+const strictMode = process.env.STRICT_MODE === 'on';
+
+const app = (
+  <QueryClientProvider client={queryClient}>
+    <QueryBoundary errorFallback={errorFallback}>
+      <Router />
+    </QueryBoundary>
+  </QueryClientProvider>
 );
+
+root.render(strictMode ? <React.StrictMode>{app}</React.StrictMode> : app);


### PR DESCRIPTION
## 📄 Summary
> 
### 🐞 Describe

### 원인
https://dev.zipgo.pet/(개발모드)에서는 <React.StrictMode>가 활성화되는데..
카카오 인증 요청 시 똑같은 토큰으로 2번(뒤에꺼는 폐기된 상태) 요청해서 아래와 같은 에러가 뜸

### 해결
```tsx
// package.json
{
...
"scripts": {
    "start:dev": "cross-env NODE_ENV=development MSW=on STRICT_MODE=on webpack serve --config config/webpack.dev.js",
    "build:dev": "cross-env NODE_ENV=development webpack STRICT_MODE=off --progress --config config/webpack.dev.js",
  ...
  },
...
}

```
```tsx
// index.tsx

...
const strictMode = process.env.STRICT_MODE === 'on';

const app = (
  <QueryClientProvider client={queryClient}>
    <QueryBoundary errorFallback={errorFallback}>
      <Router />
    </QueryBoundary>
  </QueryClientProvider>
);

root.render(strictMode ? <React.StrictMode>{app}</React.StrictMode> : app);


```
## 🙋🏻 More
> 
- close #394