### PR TITLE
feat: 반려동물 여러마리 등록 기능 추가

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,14 +4,14 @@ WORKDIR /app
 # build
 COPY . /app
 RUN yarn build:prod
-# RUN yarn build:sb
+RUN yarn build:sb
 
 # nginx 
 FROM nginx:latest
 RUN rm -rf /etc/nginx/conf.d
 COPY conf /etc/nginx
 COPY --from=builder /app/dist /usr/share/nginx/html
-# COPY --from=builder /app/storybook-static /usr/share/nginx/html/storybook
+COPY --from=builder /app/storybook-static /usr/share/nginx/html/storybook
 
 EXPOSE 3000
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -4,14 +4,14 @@ WORKDIR /app
 # build
 COPY . /app
 RUN yarn build:dev
-# RUN yarn build:sb
+RUN yarn build:sb
 
 # nginx 
 FROM nginx:latest
 RUN rm -rf /etc/nginx/conf.d
 COPY conf /etc/nginx
 COPY --from=builder /app/dist /usr/share/nginx/html
-# COPY --from=builder /app/storybook-static /usr/share/nginx/html/storybook
+COPY --from=builder /app/storybook-static /usr/share/nginx/html/storybook
 
 EXPOSE 3000
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/src/components/PetProfile/PetItem.tsx
+++ b/frontend/src/components/PetProfile/PetItem.tsx
@@ -43,6 +43,7 @@ const PetItem = (petItemProps: PetItemProps) => {
         </PetImageAndDetail>
       </PetItemContent>
       <EditLink
+        onClick={e => e.stopPropagation()}
         to={routerPath.petProfileEdition({ petId: petInfo.id })}
         aria-label="반려동물 정보 수정"
       >

--- a/frontend/src/components/PetProfile/PetList.tsx
+++ b/frontend/src/components/PetProfile/PetList.tsx
@@ -22,7 +22,7 @@ const PetList = () => {
           onClick={() => updatePetProfile(pet)}
         />
       ))}
-      {Boolean(!petList?.length) && <AddPetButton />}
+      <AddPetButton />
     </PetListLayout>
   );
 };
@@ -31,8 +31,8 @@ export default PetList;
 
 const AddPetButton = () => (
   <AddButtonWrapper to={PATH.PET_PROFILE_ADDITION}>
-    <img src={AddPetButtonIcon} alt="반려견 추가하기" />
-    <AddButtonText>반려견 등록하기</AddButtonText>
+    <img src={AddPetButtonIcon} alt="반려동물 등록버튼" />
+    <AddButtonText>우리 아이 등록하기</AddButtonText>
   </AddButtonWrapper>
 );
 

--- a/frontend/src/components/PetProfile/PetListBottomSheet.tsx
+++ b/frontend/src/components/PetProfile/PetListBottomSheet.tsx
@@ -68,7 +68,7 @@ const DialogHeader = styled.div`
   align-items: center;
 
   width: 100%;
-  height: 6rem;
+  height: 7.4rem;
   padding: 0 2rem;
 
   font-size: 1.8rem;
@@ -85,14 +85,24 @@ const DialogHeader = styled.div`
 const DialogContent = styled.div<{
   $paddingBottom?: string;
 }>`
+  scrollbar-width: none;
+
   position: relative;
 
+  overflow-y: auto;
   flex-grow: 1;
 
   width: 100%;
+  height: 50rem;
   padding: 2rem;
 
   background: ${({ theme }) => theme.color.grey200};
+
+  -ms-overflow-style: none;
+
+  &::-webkit-scrollbar {
+    width: 0;
+  }
 `;
 
 const ButtonWrapper = styled.div`

--- a/frontend/src/hooks/common/useImageUpload.ts
+++ b/frontend/src/hooks/common/useImageUpload.ts
@@ -2,7 +2,7 @@ import { ChangeEvent, useState } from 'react';
 
 import { useUploadImageMutation } from '../query/image';
 
-const MAX_FILE_SIZE = 1 * 1024 * 1024; // 1MB;
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB;
 
 export const useImageUpload = () => {
   const [previewImage, setPreviewImage] = useState('');
@@ -20,7 +20,7 @@ export const useImageUpload = () => {
 
     if (imageFile.size > MAX_FILE_SIZE) {
       e.target.value = '';
-      alert('이미지 크기가 너무 큽니다. 1MB 이하의 이미지를 업로드해주세요.');
+      alert('이미지 크기가 너무 큽니다. 5MB 이하의 이미지를 업로드해주세요.');
       return;
     }
 

--- a/frontend/src/hooks/query/auth.ts
+++ b/frontend/src/hooks/query/auth.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 import { authenticateUser, loginZipgoAuth, logoutKaKaoAuth } from '@/apis/auth';
+import { usePetProfile } from '@/context/petProfile/PetProfileContext';
 import { routerPath } from '@/router/routes';
 import { zipgoLocalStorage } from '@/utils/localStorage';
 
@@ -23,6 +24,7 @@ export const useAuthQuery = () => {
 export const useAuthMutation = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { updatePetProfile } = usePetProfile();
 
   const { mutate: loginZipgo, ...loginRestMutation } = useMutation({
     mutationFn: loginZipgoAuth,
@@ -33,8 +35,8 @@ export const useAuthMutation = () => {
       zipgoLocalStorage.setTokens({ accessToken });
       zipgoLocalStorage.setUserInfo(authResponse);
 
-      if (!selectedPet && newestPet) zipgoLocalStorage.setPetProfile(newestPet);
-      if (selectedPet && newestPet) zipgoLocalStorage.setPetProfile(selectedPet);
+      if (!selectedPet && newestPet) updatePetProfile(newestPet);
+      if (selectedPet && newestPet) updatePetProfile(selectedPet);
 
       queryClient.invalidateQueries([QUERY_KEY.authenticateUser]);
 

--- a/frontend/src/hooks/query/auth.ts
+++ b/frontend/src/hooks/query/auth.ts
@@ -35,8 +35,8 @@ export const useAuthMutation = () => {
       zipgoLocalStorage.setTokens({ accessToken });
       zipgoLocalStorage.setUserInfo(authResponse);
 
-      if (!selectedPet && newestPet) updatePetProfile(newestPet);
-      if (selectedPet && newestPet) updatePetProfile(selectedPet);
+      if (selectedPet) updatePetProfile(selectedPet);
+      else if (newestPet) updatePetProfile(newestPet);
 
       queryClient.invalidateQueries([QUERY_KEY.authenticateUser]);
 

--- a/frontend/src/hooks/query/petProfile.ts
+++ b/frontend/src/hooks/query/petProfile.ts
@@ -57,6 +57,7 @@ export const usePetListQuery = () => {
 };
 
 export const useAddPetMutation = () => {
+  const { refetch: refetchPetList } = usePetListQuery();
   const { updatePetProfile: updatePetProfileInHeader } = usePetProfile();
   const { mutate: addPet, ...addPetRestMutation } = useMutation<
     PostPetRes,
@@ -68,15 +69,13 @@ export const useAddPetMutation = () => {
     onSuccess: (postPetProfileRes, petProfile, context) => {
       const userInfo = zipgoLocalStorage.getUserInfo({ required: true });
 
-      const petProfileWithId = {
-        ...petProfile,
-        id: 1,
-        petSize: petProfile.breed === MIXED_BREED ? petProfile.petSize : PET_SIZES[0],
-      } as PetProfile;
-
-      updatePetProfileInHeader(petProfileWithId);
-
       zipgoLocalStorage.setUserInfo({ ...userInfo, hasPet: true });
+
+      refetchPetList().then(({ data }) => {
+        const newestPet = data?.pets.at(-1);
+
+        if (newestPet) updatePetProfileInHeader(newestPet);
+      });
 
       alert('반려동물 정보 등록이 완료되었습니다.');
     },

--- a/frontend/src/hooks/query/petProfile.ts
+++ b/frontend/src/hooks/query/petProfile.ts
@@ -87,7 +87,8 @@ export const useAddPetMutation = () => {
 
 export const useEditPetMutation = () => {
   const { resetPetItemQuery } = usePetItemQuery({ petId: 0 });
-  const { updatePetProfile: updatePetProfileInHeader } = usePetProfile();
+  const { petProfile: petProfileInHeader, updatePetProfile: updatePetProfileInHeader } =
+    usePetProfile();
 
   const { mutate: editPet, ...editPetRestMutation } = useMutation<
     PutPetRes,
@@ -97,7 +98,8 @@ export const useEditPetMutation = () => {
   >({
     mutationFn: putPet,
     onSuccess: (putPetRes, newPetProfile, context) => {
-      updatePetProfileInHeader(newPetProfile);
+      if (newPetProfile.id === petProfileInHeader?.id) updatePetProfileInHeader(newPetProfile);
+
       resetPetItemQuery();
 
       alert('반려동물 정보 수정이 완료되었습니다.');

--- a/frontend/src/hooks/query/review.ts
+++ b/frontend/src/hooks/query/review.ts
@@ -1,5 +1,6 @@
 /* eslint-disable indent */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 
 import {
   deleteHelpfulReactions,
@@ -12,6 +13,7 @@ import {
   postReview,
   putReview,
 } from '@/apis/review';
+import { routerPath } from '@/router/routes';
 import { Parameter } from '@/types/common/utility';
 import { GetReviewsRes } from '@/types/review/remote';
 
@@ -48,12 +50,17 @@ export const useReviewListQuery = (payload: Parameter<typeof getReviews>) => {
 };
 
 export const useAddReviewMutation = () => {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const { mutateAsync: addReview, ...addReviewRestMutation } = useMutation({
+  const { mutate: addReview, ...addReviewRestMutation } = useMutation({
     mutationFn: postReview,
     onSuccess: (_, { petFoodId }) => {
       queryClient.invalidateQueries([QUERY_KEY.reviewList, petFoodId]);
+
+      alert('리뷰 작성이 완료되었습니다.');
+
+      navigate(routerPath.foodDetail({ petFoodId }));
     },
   });
 
@@ -61,12 +68,17 @@ export const useAddReviewMutation = () => {
 };
 
 export const useEditReviewMutation = () => {
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const { mutateAsync: editReview, ...editReviewRestMutation } = useMutation({
+  const { mutate: editReview, ...editReviewRestMutation } = useMutation({
     mutationFn: putReview,
     onSuccess: (_, { petFoodId }) => {
       queryClient.invalidateQueries([QUERY_KEY.reviewList, petFoodId]);
+
+      alert('리뷰 수정이 완료되었습니다.');
+
+      navigate(routerPath.foodDetail({ petFoodId }));
     },
   });
 

--- a/frontend/src/hooks/review/useReviewForm.ts
+++ b/frontend/src/hooks/review/useReviewForm.ts
@@ -121,18 +121,12 @@ export const useReviewForm = (useReviewFormProps: UseReviewFormProps) => {
     e.preventDefault();
 
     if (isEditMode && reviewItem) {
-      editReviewMutation.editReview({ reviewId, ...review }).then(() => {
-        alert('리뷰 수정이 완료되었습니다.');
-        navigate(routerPath.foodDetail({ petFoodId }));
-      });
+      editReviewMutation.editReview({ reviewId, ...review });
 
       return;
     }
 
-    addReviewMutation.addReview(review).then(() => {
-      alert('리뷰 작성이 완료되었습니다.');
-      navigate(routerPath.foodDetail({ petFoodId }));
-    });
+    addReviewMutation.addReview(review);
   };
 
   useEffect(() => {

--- a/frontend/src/hooks/review/useReviewForm.ts
+++ b/frontend/src/hooks/review/useReviewForm.ts
@@ -10,6 +10,7 @@ import {
 import { routerPath } from '@/router/routes';
 import { AdverseReaction, StoolCondition, TastePreference } from '@/types/review/client';
 import { PostReviewReq } from '@/types/review/remote';
+import { zipgoLocalStorage } from '@/utils/localStorage';
 
 import { useAddReviewMutation, useEditReviewMutation, useReviewItemQuery } from '../query/review';
 
@@ -96,12 +97,14 @@ interface UseReviewFormProps {
 
 export const useReviewForm = (useReviewFormProps: UseReviewFormProps) => {
   const navigate = useNavigate();
+  const { id: petId } = zipgoLocalStorage.getPetProfile({ required: true });
   const { petFoodId, rating, isEditMode, reviewId } = useReviewFormProps;
   const { reviewItem } = useReviewItemQuery({ reviewId });
   const { addReviewMutation } = useAddReviewMutation();
   const { editReviewMutation } = useEditReviewMutation();
 
   const reviewInitialState: PostReviewReq = {
+    petId,
     petFoodId,
     rating,
     comment: '',

--- a/frontend/src/hooks/review/useReviewForm.ts
+++ b/frontend/src/hooks/review/useReviewForm.ts
@@ -1,5 +1,4 @@
 import { FormEvent, useEffect, useReducer } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import {
   ADVERSE_REACTIONS,
@@ -7,10 +6,9 @@ import {
   STOOL_CONDITIONS,
   TASTE_PREFERENCES,
 } from '@/constants/review';
-import { routerPath } from '@/router/routes';
+import { usePetProfile } from '@/context/petProfile/PetProfileContext';
 import { AdverseReaction, StoolCondition, TastePreference } from '@/types/review/client';
 import { PostReviewReq } from '@/types/review/remote';
-import { zipgoLocalStorage } from '@/utils/localStorage';
 
 import { useAddReviewMutation, useEditReviewMutation, useReviewItemQuery } from '../query/review';
 
@@ -96,15 +94,14 @@ interface UseReviewFormProps {
 }
 
 export const useReviewForm = (useReviewFormProps: UseReviewFormProps) => {
-  const navigate = useNavigate();
-  const { id: petId } = zipgoLocalStorage.getPetProfile({ required: true });
   const { petFoodId, rating, isEditMode, reviewId } = useReviewFormProps;
+  const { petProfile } = usePetProfile();
   const { reviewItem } = useReviewItemQuery({ reviewId });
   const { addReviewMutation } = useAddReviewMutation();
   const { editReviewMutation } = useEditReviewMutation();
 
   const reviewInitialState: PostReviewReq = {
-    petId,
+    petId: petProfile ? petProfile.id : -1,
     petFoodId,
     rating,
     comment: '',

--- a/frontend/src/types/review/remote.ts
+++ b/frontend/src/types/review/remote.ts
@@ -29,6 +29,7 @@ interface GetReviewsRes {
 }
 
 interface PostReviewReq {
+  petId: number;
   petFoodId: number;
   rating: number;
   comment: string;


### PR DESCRIPTION
## 📄 Summary
> 
![image](https://github.com/woowacourse-teams/2023-zipgo/assets/24777828/00b9cb65-6af7-475a-b4e5-0c0cd3e3bee6)


### ✨ Describe
반려동물 여러마리 등록 기능 추가 + 기타 작은 작업들을 진행했어요~

### ✅ Tasks

- [x] 반려동물 정보 등록, 수정, 삭제 시 헤더 프로필 업데이트
- [x] 반려동물 정보 수정 버튼 클릭 시 헤더 프로필 업데이트X
- [x] 리뷰 등록 시 petId도 함께 전달하도록 수정
- [x] Dockerfile 스토리북 배포 설정
- [x] 로그인 시 사용자의 반려동물 프로필이 헤더에 즉시 적용되도록 설정
- [x] 이미지 업로드 사이즈 제한 5MB로 변경 

### 🕖 예상/식제 작업 소요 시간

1시간/2시간

## 🙋🏻 More
> 

- close #396 