### PR TITLE
feat: 우리아이 맞춤 리뷰보기 기능

### DIFF
--- a/backend/src/main/java/zipgo/pet/domain/AgeGroup.java
+++ b/backend/src/main/java/zipgo/pet/domain/AgeGroup.java
@@ -4,6 +4,7 @@ package zipgo.pet.domain;
 import java.time.LocalDateTime;
 import java.time.Year;
 import java.util.Arrays;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import zipgo.pet.exception.AgeGroupNotFoundException;
@@ -25,7 +26,7 @@ public enum AgeGroup {
     public static AgeGroup from(int age) {
         return Arrays.stream(values())
                 .filter(ageGroup -> ageGroup.greaterThanOrEqual <= age && age < ageGroup.lessThan)
-                .findFirst()
+                .findAny()
                 .orElseThrow(PetAgeNotFoundException::new);
     }
 
@@ -36,6 +37,14 @@ public enum AgeGroup {
             }
         }
         throw new AgeGroupNotFoundException();
+    }
+
+    public static AgeGroup fromYear(int year) {
+        return Arrays.stream(values())
+                .filter(ageGroup -> ageGroup.calculateMinBirthYear().getValue() <= year)
+                .filter(ageGroup -> year < ageGroup.calculateMaxBirthYear().getValue())
+                .findAny()
+                .orElseThrow(PetAgeNotFoundException::new);
     }
 
     public Year calculateMinBirthYear() {

--- a/backend/src/main/java/zipgo/review/application/dto/CustomReviewDto.java
+++ b/backend/src/main/java/zipgo/review/application/dto/CustomReviewDto.java
@@ -3,13 +3,16 @@ package zipgo.review.application.dto;
 import zipgo.pet.exception.PetFoodIdNotNullException;
 import zipgo.pet.exception.ReviewSizeNegativeException;
 
-public record GetReviewQueryRequest(
+public record CustomReviewDto(
         Long petFoodId,
         int size,
-        Long lastReviewId
+        Long lastReviewId,
+        Long sortById,
+        Long petId,
+        Long memberId
 ) {
 
-    public GetReviewQueryRequest {
+    public CustomReviewDto {
         if (petFoodId == null) {
             throw new PetFoodIdNotNullException();
         }

--- a/backend/src/main/java/zipgo/review/application/dto/CustomReviewDto.java
+++ b/backend/src/main/java/zipgo/review/application/dto/CustomReviewDto.java
@@ -1,8 +1,5 @@
 package zipgo.review.application.dto;
 
-import zipgo.pet.exception.PetFoodIdNotNullException;
-import zipgo.pet.exception.ReviewSizeNegativeException;
-
 public record CustomReviewDto(
         Long petFoodId,
         int size,
@@ -11,17 +8,5 @@ public record CustomReviewDto(
         Long petId,
         Long memberId
 ) {
-
-    public CustomReviewDto {
-        if (petFoodId == null) {
-            throw new PetFoodIdNotNullException();
-        }
-        if (size <= 0) {
-            throw new ReviewSizeNegativeException();
-        }
-        if (sortById == null) {
-            sortById = 1L;
-        }
-    }
 
 }

--- a/backend/src/main/java/zipgo/review/application/dto/CustomReviewDto.java
+++ b/backend/src/main/java/zipgo/review/application/dto/CustomReviewDto.java
@@ -19,6 +19,9 @@ public record CustomReviewDto(
         if (size <= 0) {
             throw new ReviewSizeNegativeException();
         }
+        if (sortById == null) {
+            sortById = 1L;
+        }
     }
 
 }

--- a/backend/src/main/java/zipgo/review/domain/repository/ReviewQueryRepository.java
+++ b/backend/src/main/java/zipgo/review/domain/repository/ReviewQueryRepository.java
@@ -2,6 +2,7 @@ package zipgo.review.domain.repository;
 
 import java.util.List;
 import zipgo.review.domain.Review;
+import zipgo.review.domain.repository.dto.FindCustomReviewsFilterRequest;
 import zipgo.review.domain.repository.dto.FindReviewsFilterRequest;
 import zipgo.review.domain.repository.dto.FindReviewsQueryResponse;
 import zipgo.review.domain.repository.dto.ReviewHelpfulReaction;
@@ -9,6 +10,8 @@ import zipgo.review.domain.repository.dto.ReviewHelpfulReaction;
 public interface ReviewQueryRepository {
 
     List<FindReviewsQueryResponse> findReviewsBy(FindReviewsFilterRequest request);
+
+    List<FindReviewsQueryResponse> findCustomReviews(FindCustomReviewsFilterRequest request);
 
     List<Review> findReviewWithAdverseReactions(List<Long> reviewIds);
 

--- a/backend/src/main/java/zipgo/review/domain/repository/dto/FindCustomReviewsFilterRequest.java
+++ b/backend/src/main/java/zipgo/review/domain/repository/dto/FindCustomReviewsFilterRequest.java
@@ -1,0 +1,49 @@
+package zipgo.review.domain.repository.dto;
+
+import lombok.Builder;
+import zipgo.pet.domain.AgeGroup;
+import zipgo.pet.domain.Pet;
+import zipgo.review.application.SortBy;
+import zipgo.review.application.dto.CustomReviewDto;
+import zipgo.review.exception.NoPetFoodIdException;
+import zipgo.review.exception.NonPositiveSizeException;
+
+public record FindCustomReviewsFilterRequest(
+        Long petFoodId,
+        int size,
+        Long lastReviewId,
+        SortBy sortBy,
+        AgeGroup ageGroup,
+        Long breedId,
+        Long memberId
+) {
+
+    @Builder
+    public FindCustomReviewsFilterRequest {
+        if (petFoodId == null) {
+            throw new NoPetFoodIdException();
+        }
+        if (size <= 0) {
+            throw new NonPositiveSizeException();
+        }
+        if (sortBy == null) {
+            sortBy = SortBy.RECENT;
+        }
+    }
+
+    public static FindCustomReviewsFilterRequest of(
+            CustomReviewDto customReviewDto,
+            Pet pet
+    ) {
+        return new FindCustomReviewsFilterRequest(
+                customReviewDto.petFoodId(),
+                customReviewDto.size(),
+                customReviewDto.lastReviewId(),
+                SortBy.from(customReviewDto.sortById()),
+                AgeGroup.from(pet.calculateCurrentAge()),
+                pet.getBreeds().getId(),
+                customReviewDto.memberId()
+        );
+    }
+
+}

--- a/backend/src/main/java/zipgo/review/dto/request/GetCustomReviewRequest.java
+++ b/backend/src/main/java/zipgo/review/dto/request/GetCustomReviewRequest.java
@@ -2,8 +2,6 @@ package zipgo.review.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
-import zipgo.pet.exception.PetFoodIdNotNullException;
-import zipgo.pet.exception.ReviewSizeNegativeException;
 import zipgo.review.application.dto.CustomReviewDto;
 
 public record GetCustomReviewRequest(
@@ -18,12 +16,6 @@ public record GetCustomReviewRequest(
 ) {
 
     public GetCustomReviewRequest {
-        if (petFoodId == null) {
-            throw new PetFoodIdNotNullException();
-        }
-        if (size <= 0) {
-            throw new ReviewSizeNegativeException();
-        }
         if (sortById == null) {
             sortById = 1L;
         }

--- a/backend/src/main/java/zipgo/review/dto/request/GetCustomReviewRequest.java
+++ b/backend/src/main/java/zipgo/review/dto/request/GetCustomReviewRequest.java
@@ -7,7 +7,6 @@ import zipgo.review.application.dto.CustomReviewDto;
 public record GetCustomReviewRequest(
         @NotNull(message = "식품 id를 입력해주세요.")
         Long petFoodId,
-
         @Positive(message = "size는 0보다 커야합니다.")
         Integer size,
         Long lastReviewId,

--- a/backend/src/main/java/zipgo/review/dto/request/GetCustomReviewRequest.java
+++ b/backend/src/main/java/zipgo/review/dto/request/GetCustomReviewRequest.java
@@ -2,6 +2,8 @@ package zipgo.review.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import zipgo.pet.exception.PetFoodIdNotNullException;
+import zipgo.pet.exception.ReviewSizeNegativeException;
 import zipgo.review.application.dto.CustomReviewDto;
 
 public record GetCustomReviewRequest(
@@ -14,6 +16,18 @@ public record GetCustomReviewRequest(
         @NotNull(message = "반려동물 id를 입력해주세요.")
         Long petId
 ) {
+
+    public GetCustomReviewRequest {
+        if (petFoodId == null) {
+            throw new PetFoodIdNotNullException();
+        }
+        if (size <= 0) {
+            throw new ReviewSizeNegativeException();
+        }
+        if (sortById == null) {
+            sortById = 1L;
+        }
+    }
 
     public CustomReviewDto toDto(Long memberId) {
         return new CustomReviewDto(

--- a/backend/src/main/java/zipgo/review/dto/request/GetCustomReviewRequest.java
+++ b/backend/src/main/java/zipgo/review/dto/request/GetCustomReviewRequest.java
@@ -1,0 +1,30 @@
+package zipgo.review.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import zipgo.review.application.dto.CustomReviewDto;
+
+public record GetCustomReviewRequest(
+        @NotNull(message = "식품 id를 입력해주세요.")
+        Long petFoodId,
+
+        @Positive(message = "size는 0보다 커야합니다.")
+        Integer size,
+        Long lastReviewId,
+        Long sortById,
+        @NotNull(message = "반려동물 id를 입력해주세요.")
+        Long petId
+) {
+
+    public CustomReviewDto toDto(Long memberId) {
+        return new CustomReviewDto(
+                this.petFoodId,
+                this.size,
+                this.lastReviewId,
+                this.sortById,
+                this.petId,
+                memberId
+        );
+    }
+
+}

--- a/backend/src/main/java/zipgo/review/presentation/ReviewController.java
+++ b/backend/src/main/java/zipgo/review/presentation/ReviewController.java
@@ -62,7 +62,7 @@ public class ReviewController {
         return Optional.ofNullable(authCredentials).map(AuthCredentials::id).orElse(null);
     }
 
-    @GetMapping
+    @GetMapping("/custom")
     public ResponseEntity<GetReviewsResponse> getCustomReviews(
             @Auth AuthCredentials authCredentials,
             @ModelAttribute @Valid GetCustomReviewRequest request

--- a/backend/src/main/java/zipgo/review/presentation/ReviewController.java
+++ b/backend/src/main/java/zipgo/review/presentation/ReviewController.java
@@ -1,8 +1,8 @@
 package zipgo.review.presentation;
 
-import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.Optional;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,8 +19,10 @@ import zipgo.auth.presentation.Auth;
 import zipgo.auth.presentation.OptionalAuth;
 import zipgo.review.application.ReviewQueryService;
 import zipgo.review.application.ReviewService;
+import zipgo.review.application.dto.CustomReviewDto;
 import zipgo.review.domain.Review;
 import zipgo.review.dto.request.CreateReviewRequest;
+import zipgo.review.dto.request.GetCustomReviewRequest;
 import zipgo.review.dto.request.GetReviewsRequest;
 import zipgo.review.dto.request.UpdateReviewRequest;
 import zipgo.review.dto.response.GetReviewMetadataResponse;
@@ -48,7 +50,8 @@ public class ReviewController {
     @GetMapping
     public ResponseEntity<GetReviewsResponse> getAllReviews(
             @OptionalAuth AuthCredentials authCredentials,
-            @ModelAttribute @Valid GetReviewsRequest request) {
+            @ModelAttribute @Valid GetReviewsRequest request
+    ) {
         Long memberId = getMemberId(authCredentials);
         GetReviewsResponse reviews = reviewQueryService.getReviews(request.toQueryRequest(memberId));
 
@@ -57,6 +60,17 @@ public class ReviewController {
 
     private Long getMemberId(AuthCredentials authCredentials) {
         return Optional.ofNullable(authCredentials).map(AuthCredentials::id).orElse(null);
+    }
+
+    @GetMapping
+    public ResponseEntity<GetReviewsResponse> getCustomReviews(
+            @Auth AuthCredentials authCredentials,
+            @ModelAttribute @Valid GetCustomReviewRequest request
+    ) {
+        CustomReviewDto customReviewDto = request.toDto(authCredentials.id());
+        GetReviewsResponse reviews = reviewQueryService.getCustomReviews(customReviewDto);
+
+        return ResponseEntity.ok(reviews);
     }
 
     @GetMapping("/{id}")
@@ -108,7 +122,6 @@ public class ReviewController {
         reviewService.removeHelpfulReaction(authCredentials.id(), reviewId);
         return ResponseEntity.noContent().build();
     }
-
 
     @GetMapping("/summary")
     public ResponseEntity<GetReviewsSummaryResponse> getReviewsSummary(Long petFoodId) {

--- a/backend/src/test/java/zipgo/review/domain/repository/ReviewQueryRepositoryImplTest.java
+++ b/backend/src/test/java/zipgo/review/domain/repository/ReviewQueryRepositoryImplTest.java
@@ -514,7 +514,7 @@ class ReviewQueryRepositoryImplTest {
     class 맞춤_리뷰목록_필터링 {
 
         @Test
-        void 내_반려견과_같은_나이대만_필터링() {
+        void 내_아이와_같은_나이대_견종_목록만_필터링한다() {
             // given
             PetSize 사이즈 = petSizeRepository.save(소형견());
             Breeds 견종 = breedsRepository.save(Breeds.builder().petSize(사이즈).name("풍산개").build());

--- a/backend/src/test/java/zipgo/review/domain/repository/ReviewQueryRepositoryImplTest.java
+++ b/backend/src/test/java/zipgo/review/domain/repository/ReviewQueryRepositoryImplTest.java
@@ -137,7 +137,7 @@ class ReviewQueryRepositoryImplTest {
             var 리뷰_리스트 = reviewQueryRepository.findReviewsBy(요청);
 
             // then
-            assertThat(리뷰_리스트.size()).isEqualTo(10);
+            assertThat(리뷰_리스트).hasSize(10);
         }
 
 
@@ -513,16 +513,13 @@ class ReviewQueryRepositoryImplTest {
     @Nested
     class 맞춤_리뷰목록_필터링 {
 
-
         @Test
         void 내_반려견과_같은_나이대만_필터링() {
             // given
             PetSize 사이즈 = petSizeRepository.save(소형견());
             Breeds 견종 = breedsRepository.save(Breeds.builder().petSize(사이즈).name("풍산개").build());
-
             PetFood 식품 = 식품_만들기();
             랜덤_리뷰_생성(식품);
-
             종류_출생연도_리뷰_반복_생성(5, 식품, 견종, 1997);
 
             // when

--- a/backend/src/test/java/zipgo/review/domain/repository/dto/FindCustomReviewsFilterRequestTest.java
+++ b/backend/src/test/java/zipgo/review/domain/repository/dto/FindCustomReviewsFilterRequestTest.java
@@ -1,0 +1,46 @@
+package zipgo.review.domain.repository.dto;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import zipgo.review.application.SortBy;
+import zipgo.review.exception.NoPetFoodIdException;
+import zipgo.review.exception.NonPositiveSizeException;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FindCustomReviewsFilterRequestTest {
+
+    @Test
+    void 식품_id가_null이면_예외가_발생한다() {
+        // expect
+        assertThatThrownBy(
+                () -> FindCustomReviewsFilterRequest.builder()
+                        .petFoodId(null)
+                        .size(10)
+                        .lastReviewId(null)
+                        .sortBy(null)
+                        .build())
+                .isInstanceOf(NoPetFoodIdException.class);
+    }
+
+    @ParameterizedTest(name = "size가 0 이하면 예외가 발생한다 size = {0}")
+    @ValueSource(ints = {0, -1, -100, Integer.MAX_VALUE + 1})
+    void size가_0_이하면_예외가_발생한다(int 음수) {
+
+        // expect
+        assertThatThrownBy(
+                () -> FindCustomReviewsFilterRequest.builder()
+                        .petFoodId(1L)
+                        .size(음수)
+                        .lastReviewId(null)
+                        .sortBy(SortBy.RECENT)
+                        .build())
+                .isInstanceOf(NonPositiveSizeException.class);
+    }
+
+}


### PR DESCRIPTION
## 📄 Summary
> #380 

우리아이 맞춤 리뷰 기능을 만들었어요

플로우는 리뷰 보기 기능과 크게 다르지 않아요

1. 사용자로부터 petId, petFoodId를 입력받음, 
2. ReviewQueryService에서 PetRepository에서 Pet을 찾아옵니다
3. 가져온 Pet으로부터 breedId(견종 식별자), AgeGroup(나이대)를 찾아와요
4. PetQueryRepositoryImpl에서 쿼리를 날립니다!


// 쿼리!
```java
public List<FindReviewsQueryResponse> findCustomReviews(FindCustomReviewsFilterRequest request) {
    Long petFoodId = request.petFoodId();
    int size = request.size();
    Long lastReviewId = request.lastReviewId();
    Long breedId = request.breedId();
    AgeGroup ageGroup = request.ageGroup();

    return queryFactory.select(new QFindReviewsQueryResponse(
                            review.id,
                            pet.owner.id,
                            review.rating,
                            review.createdAt,
                            review.comment,
                            review.tastePreference,
                            review.stoolCondition,
                            pet.id,
                            pet.name,
                            pet.imageUrl,
                            pet.birthYear,
                            review.weight,
                            breeds.id,
                            breeds.name,
                            breeds.petSize.id,
                            breeds.petSize.name
                    )
            )
            .from(review)
            .join(review.pet, pet)
            .join(pet.breeds, breeds)
            .where(
                    equalsPetFoodId(petFoodId),
                    equalsBreedId(breedId),
                    equalsAgeGroup(ageGroup),
                    afterThan(lastReviewId)
            )
            .orderBy(getSorter(request.sortBy()))
            .limit(size)
            .fetch();
}

private BooleanExpression equalsBreedId(@NotNull Long breedId) {
    return pet.breeds.id.eq(breedId);
}

private BooleanExpression equalsAgeGroup(@NotNull AgeGroup ageGroup) {
    BooleanExpression greaterThanOrEqual = review.pet.birthYear.goe(ageGroup.calculateMinBirthYear());
    BooleanExpression lessThanOrEqual = review.pet.birthYear.loe(ageGroup.calculateMaxBirthYear());

    return Expressions.booleanOperation(Ops.AND, greaterThanOrEqual, lessThanOrEqual);
}


```

## 🙋🏻 More
> 

1. AgeGroup에 연도로부터 나이그룹을 가져오는 메서드를 하나 만들었어요

```java
public static AgeGroup fromYear(int year) {
        return Arrays.stream(values())
                .filter(ageGroup -> ageGroup.calculateMinBirthYear().getValue() <= year)
                .filter(ageGroup -> year < ageGroup.calculateMaxBirthYear().getValue())
                .findAny()
                .orElseThrow(PetAgeNotFoundException::new);
    }
```

이 메서드를 이용, API 응답으로 클라이언트에게 주는 출생연도로부터 나이그룹에 속하는지 검증해요!


2. API 주소가 `/reviews/custom`입니다

그대로 reviews를 쓰자니 쿼리스트링이 겹쳐서 사용을 못하고... 지은 이름인데
custom이 한국어 맞춤과 1:1로 대응되지 않아서 좀 꺼려졌어요
근데 더 좋은건 뭐가 있을까 생각해봤는데 딱히 이거만한 것도 없더라구요
더 좋은 아이디어가 있으면 적어주세요...!