### PR TITLE
fix: 반려동물 2마리 이상일 때 1마리 삭제 시 hasPet이 false가 돼서 리뷰 작성이 안되는 문제 해결

### DIFF
--- a/frontend/src/hooks/query/petProfile.ts
+++ b/frontend/src/hooks/query/petProfile.ts
@@ -128,18 +128,17 @@ export const useRemovePetMutation = () => {
     unknown
   >({
     mutationFn: deletePet,
-    onSuccess: (deletePetRes, deletePetReq, context) => {
+    onSuccess: async (deletePetRes, deletePetReq, context) => {
+      const { data } = await refetchPetList();
       const userInfo = zipgoLocalStorage.getUserInfo({ required: true });
 
-      zipgoLocalStorage.setUserInfo({ ...userInfo, hasPet: false });
+      if (data?.pets.length === 0) zipgoLocalStorage.setUserInfo({ ...userInfo, hasPet: false });
 
       if (deletePetReq.petId === petProfileInHeader?.id) {
-        refetchPetList().then(({ data }) => {
-          const newestPet = data?.pets.at(-1);
+        const newestPet = data?.pets.at(-1);
 
-          if (newestPet) updatePetProfileInHeader(newestPet);
-          if (!newestPet) resetPetProfileInHeader();
-        });
+        if (newestPet) updatePetProfileInHeader(newestPet);
+        if (!newestPet) resetPetProfileInHeader();
       }
 
       resetPetItemQuery();


### PR DESCRIPTION
## 📄 Summary
> 

반려동물 2마리 이상일 때 1마리 삭제 시
로컬스토리지 유저 정보의 hasPet이 false가 돼서 리뷰 작성이 안되는 문제 해결했습니다!

추후에
https://github.com/woowacourse-teams/2023-zipgo/pull/398#discussion_r1325503695 > 요거 반영하면서 얘도 리팩터링 같이 할 것 같아용

## 🙋🏻 More
> 

- close #409 