### PR TITLE
hotfix: s3 디렉토리 이름 접두사 제거

### DIFF
--- a/backend/src/main/java/zipgo/image/ImageDirectoryUrl.java
+++ b/backend/src/main/java/zipgo/image/ImageDirectoryUrl.java
@@ -2,10 +2,9 @@ package zipgo.image;
 
 public class ImageDirectoryUrl {
 
-    public final static String PREFIX_DIRECTORY = "prod/";
     public final static String SUFFIX_DIRECTORY = "-image/";
-    public final static String PET_DIRECTORY = PREFIX_DIRECTORY + "/pet" + SUFFIX_DIRECTORY;
-    public final static String BRAND_DIRECTORY = PREFIX_DIRECTORY + "/brand" + SUFFIX_DIRECTORY;
-    public final static String PET_FOOD_DIRECTORY = PREFIX_DIRECTORY + "/pet-food" + SUFFIX_DIRECTORY;
+    public final static String PET_DIRECTORY = "/pet" + SUFFIX_DIRECTORY;
+    public final static String BRAND_DIRECTORY = "/brand" + SUFFIX_DIRECTORY;
+    public final static String PET_FOOD_DIRECTORY = "/pet-food" + SUFFIX_DIRECTORY;
 
 }


### PR DESCRIPTION
## 📄 Summary
> 
<img width="798" alt="image" src="https://github.com/woowacourse-teams/2023-zipgo/assets/73161212/3b362ec7-61e8-49fa-9252-689d734eb853">

접두사로 prod가 붙어있어서, 개발환경에 들어가야할 이미지들이 모두 prod 내에 들어가있습니다
이에 제거하였습니다

## 🙋🏻 More
> 
