### PR TITLE
refactor: 조회 쿼리 개선

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
 
     implementation 'software.amazon.awssdk:s3:2.20.121'
-    compileOnly 'software.amazon.awssdk:url-connection-client:2.20.121'
+    implementation 'software.amazon.awssdk:url-connection-client:2.20.121'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.3.1'

--- a/backend/src/main/java/zipgo/common/config/S3Config.java
+++ b/backend/src/main/java/zipgo/common/config/S3Config.java
@@ -3,6 +3,8 @@ package zipgo.common.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import static software.amazon.awssdk.regions.Region.AP_NORTHEAST_2;
@@ -13,7 +15,8 @@ public class S3Config {
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
-                .credentialsProvider(InstanceProfileCredentialsProvider.builder().build())
+                .credentialsProvider(ProfileCredentialsProvider.create())
+                .httpClient(UrlConnectionHttpClient.builder().build())
                 .region(AP_NORTHEAST_2)
                 .build();
     }

--- a/backend/src/main/java/zipgo/common/config/S3Config.java
+++ b/backend/src/main/java/zipgo/common/config/S3Config.java
@@ -15,7 +15,7 @@ public class S3Config {
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
-                .credentialsProvider(ProfileCredentialsProvider.create())
+                .credentialsProvider(InstanceProfileCredentialsProvider.builder().build())
                 .httpClient(UrlConnectionHttpClient.builder().build())
                 .region(AP_NORTHEAST_2)
                 .build();

--- a/backend/src/main/java/zipgo/petfood/application/PetFoodQueryService.java
+++ b/backend/src/main/java/zipgo/petfood/application/PetFoodQueryService.java
@@ -16,6 +16,7 @@ import zipgo.petfood.dto.response.FilterResponse;
 import zipgo.petfood.dto.response.GetPetFoodQueryResponse;
 import zipgo.petfood.dto.response.GetPetFoodResponse;
 import zipgo.petfood.dto.response.GetPetFoodsResponse;
+import zipgo.petfood.exception.PetFoodNotFoundException;
 import zipgo.petfood.infra.persist.PetFoodQueryRepositoryImpl;
 
 import java.util.List;
@@ -59,7 +60,7 @@ public class PetFoodQueryService {
     }
 
     public GetPetFoodResponse getPetFoodResponse(Long id) {
-        PetFood petfood = petFoodRepository.getById(id);
+        PetFood petfood = petFoodQueryRepository.findPetFoodWithRelations(id).orElseThrow(() -> new PetFoodNotFoundException(id));
         return GetPetFoodResponse.of(petfood, petfood.calculateRatingAverage(), petfood.countReviews());
     }
 

--- a/backend/src/main/java/zipgo/petfood/application/PetFoodQueryService.java
+++ b/backend/src/main/java/zipgo/petfood/application/PetFoodQueryService.java
@@ -1,6 +1,5 @@
 package zipgo.petfood.application;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,9 +13,12 @@ import zipgo.petfood.domain.repository.PetFoodRepository;
 import zipgo.petfood.domain.repository.PrimaryIngredientRepository;
 import zipgo.petfood.dto.request.FilterRequest;
 import zipgo.petfood.dto.response.FilterResponse;
+import zipgo.petfood.dto.response.GetPetFoodQueryResponse;
 import zipgo.petfood.dto.response.GetPetFoodResponse;
 import zipgo.petfood.dto.response.GetPetFoodsResponse;
 import zipgo.petfood.infra.persist.PetFoodQueryRepositoryImpl;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -36,7 +38,7 @@ public class PetFoodQueryService {
         );
     }
 
-    private List<PetFood> getPagingPetFoods(FilterRequest filterDto, Long lastPetFoodId, int size) {
+    private List<GetPetFoodQueryResponse> getPagingPetFoods(FilterRequest filterDto, Long lastPetFoodId, int size) {
         return petFoodQueryRepository.findPagingPetFoods(
                 filterDto.brands(),
                 filterDto.nutritionStandards(),

--- a/backend/src/main/java/zipgo/petfood/domain/repository/PetFoodQueryRepository.java
+++ b/backend/src/main/java/zipgo/petfood/domain/repository/PetFoodQueryRepository.java
@@ -1,11 +1,12 @@
 package zipgo.petfood.domain.repository;
 
+import zipgo.petfood.dto.response.GetPetFoodQueryResponse;
+
 import java.util.List;
-import zipgo.petfood.domain.PetFood;
 
 public interface PetFoodQueryRepository {
 
-    List<PetFood> findPagingPetFoods(
+    List<GetPetFoodQueryResponse> findPagingPetFoods(
             List<String> brandsName,
             List<String> standards,
             List<String> primaryIngredientList,

--- a/backend/src/main/java/zipgo/petfood/dto/response/GetPetFoodQueryResponse.java
+++ b/backend/src/main/java/zipgo/petfood/dto/response/GetPetFoodQueryResponse.java
@@ -1,0 +1,17 @@
+package zipgo.petfood.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record GetPetFoodQueryResponse(
+        long petFoodId,
+        String foodName,
+        String brandName,
+        String imageUrl
+) {
+
+    @QueryProjection
+    public GetPetFoodQueryResponse {
+
+    }
+
+}

--- a/backend/src/main/java/zipgo/petfood/dto/response/GetPetFoodsResponse.java
+++ b/backend/src/main/java/zipgo/petfood/dto/response/GetPetFoodsResponse.java
@@ -1,14 +1,13 @@
 package zipgo.petfood.dto.response;
 
 import java.util.List;
-import zipgo.petfood.domain.PetFood;
 
 public record GetPetFoodsResponse(
         long totalCount,
         List<PetFoodResponse> petFoods
 ) {
 
-    public static GetPetFoodsResponse from(long totalCount, List<PetFood> petFoods) {
+    public static GetPetFoodsResponse from(long totalCount, List<GetPetFoodQueryResponse> petFoods) {
         List<PetFoodResponse> petFoodResponses = petFoods.stream()
                 .map(PetFoodResponse::from)
                 .toList();

--- a/backend/src/main/java/zipgo/petfood/dto/response/PetFoodResponse.java
+++ b/backend/src/main/java/zipgo/petfood/dto/response/PetFoodResponse.java
@@ -1,22 +1,18 @@
 package zipgo.petfood.dto.response;
 
-import zipgo.petfood.domain.PetFood;
-
 public record PetFoodResponse(
         Long id,
         String imageUrl,
         String brandName,
-        String foodName,
-        String purchaseUrl
+        String foodName
 ) {
 
-    public static PetFoodResponse from(PetFood petFood) {
+    public static PetFoodResponse from(GetPetFoodQueryResponse petFood) {
         return new PetFoodResponse(
-                petFood.getId(),
-                petFood.getImageUrl(),
-                petFood.getBrand().getName(),
-                petFood.getName(),
-                petFood.getPurchaseLink()
+                petFood.petFoodId(),
+                petFood.imageUrl(),
+                petFood.brandName(),
+                petFood.foodName()
         );
     }
 

--- a/backend/src/main/java/zipgo/petfood/infra/persist/PetFoodQueryRepositoryImpl.java
+++ b/backend/src/main/java/zipgo/petfood/infra/persist/PetFoodQueryRepositoryImpl.java
@@ -5,16 +5,19 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
+import zipgo.petfood.domain.PetFood;
 import zipgo.petfood.domain.repository.PetFoodQueryRepository;
 import zipgo.petfood.dto.response.GetPetFoodQueryResponse;
 import zipgo.petfood.dto.response.QGetPetFoodQueryResponse;
 
 import java.util.List;
+import java.util.Optional;
 
 import static zipgo.brand.domain.QBrand.brand;
 import static zipgo.petfood.domain.QPetFood.petFood;
 import static zipgo.petfood.domain.QPetFoodFunctionality.petFoodFunctionality;
 import static zipgo.petfood.domain.QPetFoodPrimaryIngredient.petFoodPrimaryIngredient;
+import static zipgo.petfood.domain.QPrimaryIngredient.primaryIngredient;
 
 @Repository
 @RequiredArgsConstructor
@@ -120,6 +123,19 @@ public class PetFoodQueryRepositoryImpl implements PetFoodQueryRepository {
                         isContainFunctionalities(functionalityList)
                 )
                 .fetchOne();
+    }
+
+    public Optional<PetFood> findPetFoodWithRelations(Long petFoodId) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(petFood)
+                .innerJoin(petFood.brand, brand)
+                .fetchJoin()
+                .innerJoin(petFood.petFoodPrimaryIngredients, petFoodPrimaryIngredient)
+                .fetchJoin()
+                .innerJoin(petFoodPrimaryIngredient.primaryIngredient, primaryIngredient)
+                .fetchJoin()
+                .where(petFood.id.eq(petFoodId))
+                .fetchOne());
     }
 
 }

--- a/backend/src/main/java/zipgo/petfood/infra/persist/PetFoodQueryRepositoryImpl.java
+++ b/backend/src/main/java/zipgo/petfood/infra/persist/PetFoodQueryRepositoryImpl.java
@@ -5,8 +5,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
-import zipgo.petfood.domain.PetFood;
 import zipgo.petfood.domain.repository.PetFoodQueryRepository;
+import zipgo.petfood.dto.response.GetPetFoodQueryResponse;
+import zipgo.petfood.dto.response.QGetPetFoodQueryResponse;
 
 import java.util.List;
 
@@ -22,7 +23,7 @@ public class PetFoodQueryRepositoryImpl implements PetFoodQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public List<PetFood> findPagingPetFoods(
+    public List<GetPetFoodQueryResponse> findPagingPetFoods(
             List<String> brandsName,
             List<String> standards,
             List<String> primaryIngredientList,
@@ -31,12 +32,16 @@ public class PetFoodQueryRepositoryImpl implements PetFoodQueryRepository {
             int size
     ) {
         return queryFactory
-                .selectDistinct(petFood)
+                .select(new QGetPetFoodQueryResponse(
+                        petFood.id,
+                        petFood.name,
+                        brand.name,
+                        petFood.imageUrl)
+                )
                 .from(petFood)
-                .join(petFood.brand, brand)
-                .join(petFood.petFoodPrimaryIngredients, petFoodPrimaryIngredient)
-                .fetchJoin()
-                .join(petFood.petFoodFunctionalities, petFoodFunctionality)
+                .innerJoin(petFood.brand, brand)
+                .innerJoin(petFood.petFoodPrimaryIngredients, petFoodPrimaryIngredient)
+                .innerJoin(petFood.petFoodFunctionalities, petFoodFunctionality)
                 .where(
                         isLessThan(lastPetFoodId),
                         isContainBrand(brandsName),
@@ -45,6 +50,7 @@ public class PetFoodQueryRepositoryImpl implements PetFoodQueryRepository {
                         isContainFunctionalities(functionalityList)
                 )
                 .orderBy(petFood.id.desc())
+                .groupBy(petFood.id)
                 .limit(size)
                 .fetch();
     }

--- a/backend/src/main/java/zipgo/review/application/ReviewQueryService.java
+++ b/backend/src/main/java/zipgo/review/application/ReviewQueryService.java
@@ -79,7 +79,7 @@ public class ReviewQueryService {
     }
 
     public GetReviewResponse getReview(Long reviewId, Long memberId) {
-        Review review = reviewRepository.getById(reviewId);
+        Review review = reviewQueryRepository.getReviewsWithReviewRelations(reviewId);
         return GetReviewResponse.from(review, memberId);
     }
 

--- a/backend/src/main/java/zipgo/review/application/ReviewQueryService.java
+++ b/backend/src/main/java/zipgo/review/application/ReviewQueryService.java
@@ -1,15 +1,8 @@
 package zipgo.review.application;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import zipgo.auth.dto.AuthCredentials;
 import zipgo.pet.domain.AgeGroup;
 import zipgo.pet.domain.repository.BreedRepository;
 import zipgo.pet.domain.repository.PetSizeRepository;
@@ -18,7 +11,6 @@ import zipgo.petfood.domain.Reviews;
 import zipgo.petfood.domain.repository.PetFoodRepository;
 import zipgo.review.domain.Review;
 import zipgo.review.domain.repository.ReviewQueryRepository;
-import zipgo.review.domain.repository.ReviewRepository;
 import zipgo.review.domain.repository.dto.FindReviewsFilterRequest;
 import zipgo.review.domain.repository.dto.FindReviewsQueryResponse;
 import zipgo.review.domain.repository.dto.ReviewHelpfulReaction;
@@ -36,6 +28,12 @@ import zipgo.review.dto.response.type.RatingSummaryResponse;
 import zipgo.review.dto.response.type.StoolConditionResponse;
 import zipgo.review.dto.response.type.TastePreferenceResponse;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
 import static java.util.stream.Collectors.toMap;
 
 @Service
@@ -46,7 +44,6 @@ public class ReviewQueryService {
     private static final int MIN_RATING = 1;
     private static final int MAX_RATING = 5;
 
-    private final ReviewRepository reviewRepository;
     private final ReviewQueryRepository reviewQueryRepository;
     private final PetFoodRepository petFoodRepository;
     private final BreedRepository breedRepository;
@@ -79,7 +76,7 @@ public class ReviewQueryService {
     }
 
     public GetReviewResponse getReview(Long reviewId, Long memberId) {
-        Review review = reviewQueryRepository.getReviewsWithReviewRelations(reviewId);
+        Review review = reviewQueryRepository.getReviewWithRelations(reviewId);
         return GetReviewResponse.from(review, memberId);
     }
 

--- a/backend/src/main/java/zipgo/review/application/ReviewQueryService.java
+++ b/backend/src/main/java/zipgo/review/application/ReviewQueryService.java
@@ -3,11 +3,13 @@ package zipgo.review.application;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import zipgo.auth.dto.AuthCredentials;
 import zipgo.pet.domain.AgeGroup;
 import zipgo.pet.domain.repository.BreedRepository;
 import zipgo.pet.domain.repository.PetSizeRepository;
@@ -25,6 +27,7 @@ import zipgo.review.domain.type.StoolCondition;
 import zipgo.review.domain.type.TastePreference;
 import zipgo.review.dto.response.GetReviewMetadataResponse;
 import zipgo.review.dto.response.GetReviewMetadataResponse.Metadata;
+import zipgo.review.dto.response.GetReviewResponse;
 import zipgo.review.dto.response.GetReviewsResponse;
 import zipgo.review.dto.response.GetReviewsSummaryResponse;
 import zipgo.review.dto.response.type.AdverseReactionResponse;
@@ -75,8 +78,9 @@ public class ReviewQueryService {
                         .toList()));
     }
 
-    public Review getReview(Long reviewId) {
-        return reviewRepository.getById(reviewId);
+    public GetReviewResponse getReview(Long reviewId, Long memberId) {
+        Review review = reviewRepository.getById(reviewId);
+        return GetReviewResponse.from(review, memberId);
     }
 
     public GetReviewMetadataResponse getReviewMetadata() {

--- a/backend/src/main/java/zipgo/review/domain/repository/ReviewQueryRepository.java
+++ b/backend/src/main/java/zipgo/review/domain/repository/ReviewQueryRepository.java
@@ -14,6 +14,6 @@ public interface ReviewQueryRepository {
 
     List<ReviewHelpfulReaction> findReviewWithHelpfulReactions(List<Long> reviewIds, Long userId);
 
-    Review getReviewsWithReviewRelations(Long reviewId);
+    Review getReviewWithRelations(Long reviewId);
 
 }

--- a/backend/src/main/java/zipgo/review/domain/repository/ReviewQueryRepository.java
+++ b/backend/src/main/java/zipgo/review/domain/repository/ReviewQueryRepository.java
@@ -14,4 +14,6 @@ public interface ReviewQueryRepository {
 
     List<ReviewHelpfulReaction> findReviewWithHelpfulReactions(List<Long> reviewIds, Long userId);
 
+    Review getReviewsWithReviewRelations(Long reviewId);
+
 }

--- a/backend/src/main/java/zipgo/review/infra/persist/ReviewQueryRepositoryImpl.java
+++ b/backend/src/main/java/zipgo/review/infra/persist/ReviewQueryRepositoryImpl.java
@@ -175,7 +175,7 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
     }
 
     @Override
-    public Review getReviewsWithReviewRelations(Long reviewId) {
+    public Review getReviewWithRelations(Long reviewId) {
         return queryFactory
                 .selectFrom(review)
                 .join(review.pet, pet)

--- a/backend/src/main/java/zipgo/review/infra/persist/ReviewQueryRepositoryImpl.java
+++ b/backend/src/main/java/zipgo/review/infra/persist/ReviewQueryRepositoryImpl.java
@@ -7,7 +7,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.validation.constraints.NotNull;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import zipgo.pet.domain.AgeGroup;
@@ -19,9 +18,12 @@ import zipgo.review.domain.repository.dto.FindReviewsQueryResponse;
 import zipgo.review.domain.repository.dto.QFindReviewsQueryResponse;
 import zipgo.review.domain.repository.dto.ReviewHelpfulReaction;
 
+import java.util.List;
+
 import static java.util.Collections.emptyList;
-import static zipgo.pet.domain.QPet.pet;
 import static zipgo.pet.domain.QBreed.breed;
+import static zipgo.pet.domain.QPet.pet;
+import static zipgo.pet.domain.QPetSize.petSize;
 import static zipgo.review.domain.QAdverseReaction.adverseReaction;
 import static zipgo.review.domain.QHelpfulReaction.helpfulReaction;
 import static zipgo.review.domain.QReview.review;
@@ -170,6 +172,23 @@ public class ReviewQueryRepositoryImpl implements ReviewQueryRepository {
             Long count = tuple.get(review.helpfulReactions.size()).longValue();
             return new ReviewHelpfulReaction(reviewId, count, reviewIdsReactedByMember.contains(reviewId));
         }).toList();
+    }
+
+    @Override
+    public Review getReviewsWithReviewRelations(Long reviewId) {
+        return queryFactory
+                .selectFrom(review)
+                .join(review.pet, pet)
+                .fetchJoin()
+                .join(pet.breed, breed)
+                .fetchJoin()
+                .join(breed.petSize, petSize)
+                .fetchJoin()
+                .leftJoin(review.helpfulReactions, helpfulReaction)
+                .fetchJoin()
+                .join(review.adverseReactions, adverseReaction)
+                .where(review.id.eq(reviewId))
+                .fetchOne();
     }
 
 }

--- a/backend/src/main/java/zipgo/review/presentation/ReviewController.java
+++ b/backend/src/main/java/zipgo/review/presentation/ReviewController.java
@@ -61,9 +61,8 @@ public class ReviewController {
 
     @GetMapping("/{id}")
     public ResponseEntity<GetReviewResponse> getReview(@OptionalAuth AuthCredentials authCredentials, @PathVariable Long id) {
-        Review review = reviewQueryService.getReview(id);
-        Long memberId = getMemberId(authCredentials);
-        return ResponseEntity.ok(GetReviewResponse.from(review, memberId));
+        GetReviewResponse getReviewResponse = reviewQueryService.getReview(id, getMemberId(authCredentials));
+        return ResponseEntity.ok(getReviewResponse);
     }
 
     @PutMapping("/{reviewId}")

--- a/backend/src/test/java/zipgo/petfood/application/PetFoodQueryServiceTest.java
+++ b/backend/src/test/java/zipgo/petfood/application/PetFoodQueryServiceTest.java
@@ -358,12 +358,11 @@ class PetFoodQueryServiceTest extends ServiceTest {
         @Test
         void 식품_상세조회할수_있다() {
             //given
-            Brand 브랜드 = brandRepository.findAll().get(0);
-            PetFood 테스트용_식품 = 모든_영양기준_만족_식품(브랜드);
-            Long 아이디 = petFoodRepository.save(테스트용_식품).getId();
+            PetFood 테스트용_식품 = petFoodRepository.findAll().get(0);
+            Brand 브랜드 = brandRepository.findById(테스트용_식품.getBrand().getId()).get();
 
             //when
-            GetPetFoodResponse 응답 = petFoodQueryService.getPetFoodResponse(아이디);
+            GetPetFoodResponse 응답 = petFoodQueryService.getPetFoodResponse(테스트용_식품.getId());
 
             //then
             assertThat(응답.id()).isEqualTo(테스트용_식품.getId());

--- a/backend/src/test/java/zipgo/petfood/infra/persist/PetFoodQueryRepositoryTest.java
+++ b/backend/src/test/java/zipgo/petfood/infra/persist/PetFoodQueryRepositoryTest.java
@@ -17,6 +17,7 @@ import zipgo.petfood.domain.PrimaryIngredient;
 import zipgo.petfood.domain.repository.FunctionalityRepository;
 import zipgo.petfood.domain.repository.PetFoodRepository;
 import zipgo.petfood.domain.repository.PrimaryIngredientRepository;
+import zipgo.petfood.dto.response.GetPetFoodQueryResponse;
 
 import static java.util.Collections.EMPTY_LIST;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -108,15 +109,15 @@ class PetFoodQueryRepositoryTest {
         List<String> functionalityList = EMPTY_LIST;
 
         // when
-        List<PetFood> petFoods = petFoodQueryRepository.findPagingPetFoods(brandsName, standards, primaryIngredientList,
+        List<GetPetFoodQueryResponse> responses = petFoodQueryRepository.findPagingPetFoods(brandsName, standards, primaryIngredientList,
                 functionalityList, lastPetFoodId, 20);
 
         // then
         Assertions.assertAll(
-                () -> assertThat(petFoods).hasSize(1),
-                () -> assertThat(petFoods).extracting(PetFood::getName)
+                () -> assertThat(responses).hasSize(1),
+                () -> assertThat(responses).extracting(GetPetFoodQueryResponse::foodName)
                         .contains("미국 영양기준 만족 식품"),
-                () -> assertThat(petFoods).extracting(petFood -> petFood.getBrand().getName())
+                () -> assertThat(responses).extracting(GetPetFoodQueryResponse::brandName)
                         .contains("오리젠")
         );
     }
@@ -138,11 +139,11 @@ class PetFoodQueryRepositoryTest {
         List<String> functionalityList = EMPTY_LIST;
 
         // when
-        List<PetFood> petFoods = petFoodQueryRepository.findPagingPetFoods(brandsName, standards, primaryIngredientList,
+        List<GetPetFoodQueryResponse> responses = petFoodQueryRepository.findPagingPetFoods(brandsName, standards, primaryIngredientList,
                 functionalityList, lastPetFoodId, 20);
 
         // then
-        assertThat(petFoods).hasSize(3);
+        assertThat(responses).hasSize(3);
     }
 
 }

--- a/backend/src/test/java/zipgo/petfood/presentation/PetFoodControllerTest.java
+++ b/backend/src/test/java/zipgo/petfood/presentation/PetFoodControllerTest.java
@@ -148,8 +148,7 @@ public class PetFoodControllerTest extends AcceptanceTest {
                             fieldWithPath("petFoods[].id").description("식품 id").type(JsonFieldType.NUMBER),
                             fieldWithPath("petFoods[].imageUrl").description("식품 이미지 url").type(JsonFieldType.STRING),
                             fieldWithPath("petFoods[].brandName").description("브랜드 이름").type(JsonFieldType.STRING),
-                            fieldWithPath("petFoods[].foodName").description("식품 이름").type(JsonFieldType.STRING),
-                            fieldWithPath("petFoods[].purchaseUrl").description("구매 링크").type(JsonFieldType.STRING)
+                            fieldWithPath("petFoods[].foodName").description("식품 이름").type(JsonFieldType.STRING)
                     ));
         }
 

--- a/backend/src/test/java/zipgo/review/application/ReviewQueryServiceTest.java
+++ b/backend/src/test/java/zipgo/review/application/ReviewQueryServiceTest.java
@@ -140,17 +140,19 @@ class ReviewQueryServiceTest extends QueryServiceTest {
         Review 극찬_리뷰 = reviewRepository.save(극찬_리뷰_생성(반려동물, 식품, List.of("없어요")));
 
         //when
-        Review review = reviewQueryService.getReview(극찬_리뷰.getId());
+        GetReviewResponse getReviewResponse = reviewQueryService.getReview(극찬_리뷰.getId(), 멤버.getId());
 
         //then
-        assertAll(() -> assertThat(review.getPet().getOwner().getName()).isEqualTo("무민"),
-                () -> assertThat(review.getPet().getName()).isEqualTo("무민이"),
-                () -> assertThat(review.getRating()).isEqualTo(5),
-                () -> assertThat(review.getComment()).isEqualTo("우리 아이랑 너무 잘 맞아요!"),
-                () -> assertThat(review.getTastePreference()).isEqualTo(EATS_VERY_WELL),
-                () -> assertThat(review.getStoolCondition()).isEqualTo(SOFT_MOIST),
-                () -> assertThat(review.getPet().getOwner().getId()).isEqualTo(멤버.getId()),
-                () -> assertThat(review.getAdverseReactions().get(0).getAdverseReactionType()).isEqualTo(NONE));
+        assertAll(
+                () -> assertThat(getReviewResponse.id()).isEqualTo(극찬_리뷰.getId()),
+                () -> assertThat(getReviewResponse.writerId()).isEqualTo(멤버.getId()),
+                () -> assertThat(getReviewResponse.rating()).isEqualTo(5),
+                () -> assertThat(getReviewResponse.comment()).isEqualTo("우리 아이랑 너무 잘 맞아요!"),
+                () -> assertThat(getReviewResponse.tastePreference()).isEqualTo(EATS_VERY_WELL.getDescription()),
+                () -> assertThat(getReviewResponse.stoolCondition()).isEqualTo(SOFT_MOIST.getDescription()),
+                () -> assertThat(getReviewResponse.petProfile().name()).isEqualTo("무민이"),
+                () -> assertThat(getReviewResponse.adverseReactions().get(0)).isEqualTo(NONE.getDescription())
+        );
     }
 
     @Test

--- a/backend/src/test/java/zipgo/review/application/ReviewsServiceTest.java
+++ b/backend/src/test/java/zipgo/review/application/ReviewsServiceTest.java
@@ -109,7 +109,7 @@ class ReviewsServiceTest extends ServiceTest {
                 () -> assertThat(review.getComment()).isEqualTo("우리 아이랑 너무 잘 맞아요!"),
                 () -> assertThat(review.getTastePreference()).isEqualTo(EATS_VERY_WELL),
                 () -> assertThat(review.getStoolCondition()).isEqualTo(SOFT_MOIST),
-                () -> assertThat(review.getAdverseReactions()).isEmpty()
+                () -> assertThat(review.getAdverseReactions()).hasSize(1)
         );
     }
 

--- a/backend/src/test/java/zipgo/review/fixture/ReviewFixture.java
+++ b/backend/src/test/java/zipgo/review/fixture/ReviewFixture.java
@@ -23,7 +23,7 @@ public class ReviewFixture {
                 "우리 아이랑 너무 잘 맞아요!",
                 "정말 잘 먹어요",
                 "촉촉 말랑해요",
-                new ArrayList<>()
+                List.of("먹고 토해요")
         );
     }
 


### PR DESCRIPTION
## 📄 Summary
- #423 
현재 가장 유의미해보이는 api 3개 쿼리 개선해보았습니다. 내일 ngrinder로 성능 테스트 할 예정입니다.

1. 펫푸드 조회 쿼리
  - 불필요한 필드 제거 후 dto 반환
  - 중복 제거 distinct -> group by
    - 데이터 100만 건 기준으로 distinct로 조회했을 떄 1분 걸렸는데 group by로 조회시 100ms만에 조회, 왜 그런지는 좀 더 알아볼 예정
2. 개별 리뷰 조회 
  - 원래 6개에서 2개로 (before: 70 ~ 110ms, after 10 ~ 30ms)
4. 개별 식품 조회
  - 원래 6개에서 4개로

대부분의 쿼리는 한방 쿼리 또는 인덱스를 알아서 잘타고 있엇기 때문에 딱히 인덱스를 걸 일은 없었네요..

한방 쿼리로 하다 보니 한방 쿼리가 무조건 좋은가(또는 성능이 유의미하게 늘어나는가) 라는 의문이 들더군요.. 이 부분 좀더 공부해서 공유드리겠습니다.
그리고 아직 정확하게 성능 측정을 한게 아니다보니 아직 애매하네요. 내일 ngrinder로 좀 더 정확히 해보겠습니다~


## 🙋🏻 More
> 
