### PR TITLE
fix: sharp 라이브러리 관련 도커파일 수정

### DIFF
--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -3,6 +3,7 @@ WORKDIR /app
 
 # build
 COPY . /app
+RUN yarn add sharp --platform=linux --arch=arm64
 RUN yarn build:dev
 #RUN yarn build:sb
 


### PR DESCRIPTION
## 📄 Summary
> 

sharp라이브러리가 현재 아키텍처에 맞게 설치되도록 도커파일에 아래와 같은 명령어를 추가해주려고 해여
```tsx
RUN yarn add sharp --platform=linux --arch=arm64
```

```tsx
// Dockerfile.dev

FROM --platform=linux/arm64 node:18.16.1-alpine as builder
WORKDIR /app

# build
COPY . /app
RUN yarn add sharp --platform=linux --arch=arm64 # 추가!!
RUN yarn build:dev

# nginx 
FROM nginx:latest
RUN rm -rf /etc/nginx/conf.d
COPY conf /etc/nginx
COPY --from=builder /app/dist /usr/share/nginx/html

EXPOSE 3000
CMD ["nginx", "-g", "daemon off;"]
```
