### PR TITLE
fix: 도커파일 잘못된 명령어 수정

### DIFF
--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -3,7 +3,7 @@ WORKDIR /app
 
 # build
 COPY . /app
-RUN yarn add sharp --platform=linux --arch=arm64
+RUN yarn add sharp
 RUN yarn build:dev
 #RUN yarn build:sb
 

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -3,6 +3,7 @@ WORKDIR /app
 
 # build
 COPY . /app
+RUN yarn add sharp --platform=linux --arch=arm64
 RUN yarn build:dev
 #RUN yarn build:sb
 


### PR DESCRIPTION
## 📄 Summary
> 
> sharp라이브러리가 현재 아키텍처에 맞게 설치되도록 도커파일에 아래와 같은 명령어를 추가해주려고 해여
> 예상되는 문제 원인은 GitHub Actions와 Docker 컨테이너 간에 호환되지 않는 아키텍처 라이브러리를 설치했기 때문인 것 같습니다.
> GitHub Actions는 주로 x86_64 (amd64) 아키텍처, Docker 컨테이너는 arm64 아키텍처로 빌드되는 경우가 많대요

`RUN yarn add sharp --platform=linux --arch=arm64`에서 --platform 및 --arch 옵션은 yarn 명령어에는 사용되지 않는 옵션이라구해서 다시 수정합니다..

```tsx
RUN yarn add sharp
```

```tsx
// Dockerfile.dev

FROM --platform=linux/arm64 node:18.16.1-alpine as builder
WORKDIR /app

# build
COPY . /app
RUN yarn add sharp # 추가!!
RUN yarn build:dev

# nginx 
FROM nginx:latest
RUN rm -rf /etc/nginx/conf.d
COPY conf /etc/nginx
COPY --from=builder /app/dist /usr/share/nginx/html

EXPOSE 3000
CMD ["nginx", "-g", "daemon off;"]
```