### PR TITLE
chore: 스토리북 S3 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/frontend-storybook-deploy.yml
+++ b/.github/workflows/frontend-storybook-deploy.yml
@@ -1,0 +1,78 @@
+name: Frontend Storybook Deploy To S3
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - frontend/**
+      - .github/**
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: ./frontend
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Use repository source
+        uses: actions/checkout@v3
+
+      - name: Use node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+
+      - name: Cache Yarn global cache
+        uses: actions/cache@v3
+        with:
+          path: ./.yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Cache Yarn project cache
+        uses: actions/cache@v3
+        with:
+          path: ./.yarn/cache
+          key: ${{ runner.os }}-yarn-project-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-project-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build Storybook
+        run: yarn build:sb
+
+      - name: Upload storybook build files to temp artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Storybook
+          path: frontend/storybook-static
+  deploy:
+    needs: build
+    runs-on: front-dev-server
+    steps:
+      - name: Remove previous version app
+        working-directory: .
+        run: rm -rf frontend/storybook
+
+      - name: Download the built file to AWS EC2
+        uses: actions/download-artifact@v3
+        with:
+          name: Storybook
+          path: frontend/storybook
+
+      - name: Upload to S3
+        run: |
+          aws s3 sync frontend/storybook s3://2023-team-project/2023-zipgo/storybook --delete
+      - name: Cloudfront invalidation
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.AWS_DISTRIBUTION_ID }} \
+            --paths "/storybook/*"


### PR DESCRIPTION
## 📄 Summary
> 
EC2 aws cli를 사용하여 스토리북을 S3로 배포하려고합니다!

현재 이미지 저장용 s3가 1개 있어서 요걸 사용하려고 해요.
그래서 아마 배포 후 접근은 `image.zipgo.pet/storybook/index.html` 경로로 들어가야 할 것 같습니디. 
아니면 CloudFront배포 주소+`/storybook/index.html`로도 접근할 수 있을 것 같아요.

## 참고해주세요 ~~~~
### 문제상황
깃허브액션에서 도커 컨테이너 생성 시 스토리북 빌드 부분에서 문제가 있었음

### 시도한, 생각한 다른 방법
1. 깃허브액션에서의 아키텍처 환경과 도커 컨테이너 내부 환경이 달라서 패키지 설치가 제대로 설치되지 않는 것 같아서(추측) 도커 베이스이미지를 node:18.16.1-alpine에서 두 환경 모두 지원하는 node로 바꿔보았으나 안됨
2. 깃허브액션에서 바로 s3로 빌드 파일을 업로드하려 했으나 해당 작업은 aws key가 필요한데 보안상의 이유로 받을 수 없음..

### 결론
깃허브액션에서 ec2 서버(s3에 접근할 수 있는 IAM권한을 가지고있음)를 self-hosted runner로 등록해서 aws cli를 사용해 ec2 > s3로 빌드파일 업로드하는 방식으로 워크플로우를 작성했습니다.

다른 레포에서 한번 시도 해봤는데 잘 되더라고여 우리 프로젝트에서도 잘 되겠죠..?
## 🙋🏻 More
> 
- close #462 
