### PR TITLE
fix: 스토리북 배포 워크플로우에서 캐시 무효화 로직 삭제 및 mockServiceWorker 경로 수정

### DIFF
--- a/.github/workflows/frontend-storybook-deploy.yml
+++ b/.github/workflows/frontend-storybook-deploy.yml
@@ -71,8 +71,3 @@ jobs:
       - name: Upload to S3
         run: |
           aws s3 sync frontend/storybook s3://2023-team-project/2023-zipgo/storybook --delete
-      - name: Cloudfront invalidation
-        run: |
-          aws cloudfront create-invalidation \
-            --distribution-id ${{ secrets.AWS_DISTRIBUTION_ID }} \
-            --paths "/storybook/*"

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -8,7 +8,18 @@ import { initialize, mswDecorator } from 'msw-storybook-addon';
 import { withRouter } from 'storybook-addon-react-router-v6';
 import handlers from '../src/mocks/handlers';
 
-initialize(); // msw-storybook-addon
+let options = {};
+
+if (location.hostname.includes('cloudfront')) {
+  options = {
+    serviceWorker: {
+      url: '/storybook/mockServiceWorker.js',
+    },
+  };
+}
+
+// Initialize MSW
+initialize(options);
 
 const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION
## 📄 Summary
> 

- 클라우드 프론트 권한이 없어서 캐시 무효화 로직을 수행하지 못함 > 그래서 해당 로직을 삭제했습니다.
- 스토리북에서 mockServiceWorker를 https://d18wpz6q8kn3i7.cloudfront.net/mockServiceWorker.js에서 찾는 문제가 있는데 로컬호스트네임에 따라서 경로를 바꿔주는 로직을 추가해서 d18wpz6q8kn3i7.cloudfront.net/storybook/mockServiceWorker.js에서 찾도록 설정했습니다.

```tsx
// preview.tsx
let options = {};

if (location.hostname.includes('cloudfront')) {
  options = {
    serviceWorker: {
      url: '/storybook/mockServiceWorker.js',
    },
  };
}

// Initialize MSW
initialize(options);
```

## 🙋🏻 More
> 

- close #465 
