### PR TITLE
feat: 모바일 디바이스(ios)에서 <input>, <textarea> 포커스 시 자동 zoom-in되는 현상 개선

### DIFF
--- a/frontend/src/components/@common/Input/Input.tsx
+++ b/frontend/src/components/@common/Input/Input.tsx
@@ -23,7 +23,8 @@ const InputWrapper = styled.input<InputStyleProps>`
   height: 100%;
   padding: 1.2rem;
 
-  font-size: ${({ $fontSize }) => $fontSize || '1.4rem'};
+  font-size: ${({ $fontSize }) =>
+    ($fontSize && $fontSize < '1.6rem') || !$fontSize ? '16px' : $fontSize};
 
   border: none;
   outline: none;

--- a/frontend/src/components/@common/Label/Label.tsx
+++ b/frontend/src/components/@common/Label/Label.tsx
@@ -135,15 +135,11 @@ const LabelWrapper = styled.div<LabelStyleProps>`
 
   background-color: ${({ $clicked, theme, $backgroundColor }) =>
     $clicked ? theme.color.blue : $backgroundColor};
+  border: 1px solid ${({ theme }) => theme.color.blue};
   border-radius: 20px;
 
   ${({ $hasBorder, $clicked, $borderColor }) =>
-    $hasBorder &&
-    !$clicked &&
-    `
-        outline: 1px solid ${$borderColor};
-        outline-offset: -1px;
-    `}
+    $hasBorder && !$clicked && `border-color: ${$borderColor};`}
 
   ${({ onClick }) => onClick && 'cursor: pointer'};
 `;

--- a/frontend/src/components/Food/FilterBottomSheet/MainIngredientsFilterList/MainIngredientsFilterList.tsx
+++ b/frontend/src/components/Food/FilterBottomSheet/MainIngredientsFilterList/MainIngredientsFilterList.tsx
@@ -15,27 +15,21 @@ const MainIngredientsFilterList = (props: MainIngredientsFilterListProps) => {
 
   return (
     <MainIngredientsFilterListLayout>
-      {filterList
-        .concat(filterList)
-        .concat(filterList)
-        .concat(filterList)
-        .concat(filterList)
-        .concat(filterList)
-        .map(({ id, ingredients }) => {
-          const selected = selectedFilterList[MAIN_INGREDIENTS].has(ingredients);
+      {filterList.map(({ id, ingredients }) => {
+        const selected = selectedFilterList[MAIN_INGREDIENTS].has(ingredients);
 
-          return (
-            <IngredientFilterItem
-              role="checkbox"
-              key={id}
-              aria-checked={selected}
-              $selected={selected}
-              onClick={() => toggleFilter(MAIN_INGREDIENTS, ingredients)}
-            >
-              {ingredients}
-            </IngredientFilterItem>
-          );
-        })}
+        return (
+          <IngredientFilterItem
+            role="checkbox"
+            key={id}
+            aria-checked={selected}
+            $selected={selected}
+            onClick={() => toggleFilter(MAIN_INGREDIENTS, ingredients)}
+          >
+            {ingredients}
+          </IngredientFilterItem>
+        );
+      })}
     </MainIngredientsFilterListLayout>
   );
 };

--- a/frontend/src/components/PetProfile/PetAgeSelect.tsx
+++ b/frontend/src/components/PetProfile/PetAgeSelect.tsx
@@ -34,7 +34,7 @@ const AgeSelect = styled.select`
   width: 100%;
   padding: 1.2rem;
 
-  font-size: 1.3rem;
+  font-size: 1.6rem;
   color: ${({ theme }) => theme.color.grey600};
 
   border: none;

--- a/frontend/src/components/PetProfile/PetBreedSelect.tsx
+++ b/frontend/src/components/PetProfile/PetBreedSelect.tsx
@@ -33,7 +33,7 @@ const BreedSelect = styled.select`
   width: 100%;
   padding: 1.2rem;
 
-  font-size: 1.3rem;
+  font-size: 1.6rem;
   color: ${({ theme }) => theme.color.grey600};
 
   border: none;

--- a/frontend/src/components/PetProfile/PetProfileEditionForm/PetProfileEditionForm.tsx
+++ b/frontend/src/components/PetProfile/PetProfileEditionForm/PetProfileEditionForm.tsx
@@ -176,7 +176,7 @@ const Kg = styled.p`
   top: 1.2rem;
   right: 1.2rem;
 
-  font-size: 1.3rem;
+  font-size: 1.6rem;
   font-weight: 500;
   line-height: 1.7rem;
   color: ${({ theme }) => theme.color.grey600};

--- a/frontend/src/components/Review/ReviewForm/ReviewForm.tsx
+++ b/frontend/src/components/Review/ReviewForm/ReviewForm.tsx
@@ -141,7 +141,6 @@ const DetailReviewText = styled.textarea<{ $isValid: boolean }>`
   min-height: 12rem;
   padding: 1.2rem;
 
-  font-size: 1.6rem;
   line-height: 2.4rem;
   color: ${({ theme }) => theme.color.grey500};
 
@@ -168,7 +167,7 @@ const SubmitButton = styled.button`
   width: 100vw;
   height: 9rem;
 
-  font-size: 1.6rem;
+  font-size: 2rem;
   font-weight: 700;
   line-height: 2.4rem;
   color: ${({ theme }) => theme.color.white};

--- a/frontend/src/components/Review/ReviewListAndChart/ReviewControls/AlignSelect/AlignSelect.tsx
+++ b/frontend/src/components/Review/ReviewListAndChart/ReviewControls/AlignSelect/AlignSelect.tsx
@@ -52,10 +52,6 @@ const Select = styled.select<StyledProps>`
   color: ${({ theme }) => theme.color.grey400};
   text-align: center;
 
-  /* stylelint-disable-next-line CssSyntaxError */
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
   background-color: ${({ theme }) => theme.color.grey200};
   border: none;
   border-radius: 4px;
@@ -64,7 +60,6 @@ const Select = styled.select<StyledProps>`
     $skeleton &&
     css`
       ${theme.animation.skeleton}
-      appearance: none;
       border-radius: 4px;
     `};
 `;

--- a/frontend/src/components/Review/ReviewListAndChart/ReviewControls/FilterDialog/FilterDialog.tsx
+++ b/frontend/src/components/Review/ReviewListAndChart/ReviewControls/FilterDialog/FilterDialog.tsx
@@ -264,10 +264,6 @@ const Select = styled.select`
   color: ${({ theme }) => theme.color.grey400};
   text-align: center;
 
-  /* stylelint-disable-next-line CssSyntaxError */
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
   border: 1px solid ${({ theme }) => theme.color.grey400};
   border-radius: 16px;
 `;

--- a/frontend/src/pages/PetProfile/PetProfileAddition/PetProfileNameAddition.tsx
+++ b/frontend/src/pages/PetProfile/PetProfileAddition/PetProfileNameAddition.tsx
@@ -32,7 +32,6 @@ const PetProfileNameAddition = (props: PetProfileNameAdditionProps) => {
         isValid={isFirstRenderedOrValidInput}
         onChange={onChangeName}
         design="underline"
-        fontSize="1.3rem"
       />
       <ErrorCaption>
         {!isFirstRenderedOrValidInput &&

--- a/frontend/src/pages/PetProfile/PetProfileAddition/PetProfileWeightAddition.tsx
+++ b/frontend/src/pages/PetProfile/PetProfileAddition/PetProfileWeightAddition.tsx
@@ -36,7 +36,6 @@ const PetProfileWeightAddition = (props: PetProfileWeightAddition) => {
           isValid={isFirstRenderedOrValidInput}
           onChange={onChangeWeight}
           design="underline"
-          fontSize="1.3rem"
           inputMode="decimal"
         />
         <Kg>kg</Kg>
@@ -109,7 +108,7 @@ const Kg = styled.p`
   top: 1.2rem;
   right: 1.2rem;
 
-  font-size: 1.3rem;
+  font-size: 1.6rem;
   font-weight: 500;
   line-height: 1.7rem;
   color: ${({ theme }) => theme.color.grey600};

--- a/frontend/src/styles/globalStyle.ts
+++ b/frontend/src/styles/globalStyle.ts
@@ -53,6 +53,27 @@ const globalStyle = css`
   button {
     cursor: pointer;
   }
+
+  input,
+  textarea {
+    /* stylelint-disable-next-line declaration-property-unit-allowed-list */
+    font-size: 16px;
+
+    -webkit-appearance: none;
+    appearance: none;
+    -webkit-border-radius: 0;
+    border-radius: 0;
+  }
+
+  select {
+    /* stylelint-disable-next-line declaration-property-unit-allowed-list */
+    font-size: 16px;
+
+    -webkit-appearance: none;
+    appearance: none;
+    background-color: transparent;
+    outline: none;
+  }
 `;
 
 export default globalStyle;

--- a/frontend/src/styles/globalStyle.ts
+++ b/frontend/src/styles/globalStyle.ts
@@ -72,6 +72,8 @@ const globalStyle = css`
     -webkit-appearance: none;
     appearance: none;
     background-color: transparent;
+    -webkit-border-radius: 0;
+    border-radius: 0;
     outline: none;
   }
 `;


### PR DESCRIPTION
## 📄 Summary
모바일 디바이스에서 `<input>`, `<textarea>` 포커스 시 자동 zoom-in되는 현상을 개선했습니다.
`font-size`가 `16px`보다 작으면 자동으로 zoom-in된다고 해요. 

이를 개선하기 위한 3가지 방법이 있습니다.
1. input, textarea에서는 `font-size`를 `16px`이상으로 바꾸기
2. `<meta>`를 이용해 확대 자체를 막기 
  `<meta
    name="viewport"
    content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"
/>`
3. 폰트 크기는 16px로 적용하고 `transform: scale()`을 이용해서 원하는 폰트 크기로 조절하기

고민을 해봤는데.. 1번 방법을 적용했어요.
아무래도 사용자가 편하게 쓸 수 있어야 하니까요!

W3C/WAI 모바일 접근성 가이드[(Zoom/Magnification)](https://www.w3.org/TR/mobile-accessibility-mapping/#zoom-magnification)에서도 메타 요소의 사용자 확장 가능 속성 및 최대 규모 속성에 대해 제한하는 건 피하는 게 좋다고 합니다.
> Ensure that the browser pinch zoom is not blocked by the page's viewport meta element so that it can be used to zoom the page to 200%. Restrictive values for user-scalable and maximum-scale attributes of this meta element should be avoided. Note: Relying on full viewport zooming (e.g. not blocking the browser's pinch zoom feature) requires the user to pan horizontally as well as vertically. While this technique meets the success criteria it is less usable than supporting text resizing features that reflow content to the user's chosen viewport size. It is best practice to use techniques that support text resizing without requiring horizontal panning.

## 🙋🏻 More
> 
