### PR TITLE
feat: 쿠키 내 samesite=None 옵션 추가

### DIFF
--- a/backend/src/main/java/zipgo/auth/support/RefreshTokenCookieProvider.java
+++ b/backend/src/main/java/zipgo/auth/support/RefreshTokenCookieProvider.java
@@ -22,8 +22,8 @@ public class RefreshTokenCookieProvider {
 
     public ResponseCookie createCookie(String refreshToken) {
         return ResponseCookie.from(REFRESH_TOKEN, refreshToken)
-                .maxAge(Duration.ofMillis(expirationTime))
                 .sameSite("None")
+                .maxAge(Duration.ofMillis(expirationTime))
                 .path(VALID_COOKIE_PATH)
                 .secure(true)
                 .httpOnly(true)

--- a/backend/src/main/java/zipgo/auth/support/RefreshTokenCookieProvider.java
+++ b/backend/src/main/java/zipgo/auth/support/RefreshTokenCookieProvider.java
@@ -23,6 +23,7 @@ public class RefreshTokenCookieProvider {
     public ResponseCookie createCookie(String refreshToken) {
         return ResponseCookie.from(REFRESH_TOKEN, refreshToken)
                 .maxAge(Duration.ofMillis(expirationTime))
+                .sameSite("None")
                 .path(VALID_COOKIE_PATH)
                 .secure(true)
                 .httpOnly(true)
@@ -31,6 +32,7 @@ public class RefreshTokenCookieProvider {
 
     public ResponseCookie createLogoutCookie() {
         return ResponseCookie.from(REFRESH_TOKEN, LOGOUT_COOKIE_VALUE)
+                .sameSite("None")
                 .maxAge(LOGOUT_COOKIE_AGE)
                 .build();
     }

--- a/backend/src/main/java/zipgo/common/config/WebConfig.java
+++ b/backend/src/main/java/zipgo/common/config/WebConfig.java
@@ -1,6 +1,7 @@
 package zipgo.common.config;
 
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -14,6 +15,7 @@ import zipgo.auth.support.JwtProvider;
 import zipgo.common.interceptor.LoggingInterceptor;
 
 import static org.springframework.http.HttpHeaders.LOCATION;
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
 
 @Configuration
 @RequiredArgsConstructor
@@ -34,8 +36,14 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping(ALLOW_ALL_PATH)
                 .allowedMethods(ALLOWED_METHODS)
-                .allowedOrigins(MAIN_SERVER_DOMAIN, DEV_SERVER_DOMAIN, FRONTEND_LOCALHOST, HTTPS_FRONTEND_LOCALHOST)
-                .exposedHeaders(LOCATION);
+                .allowedOrigins(
+                        MAIN_SERVER_DOMAIN,
+                        DEV_SERVER_DOMAIN,
+                        FRONTEND_LOCALHOST,
+                        HTTPS_FRONTEND_LOCALHOST
+                )
+                .allowCredentials(true)
+                .exposedHeaders(LOCATION, SET_COOKIE);
     }
 
     @Override


### PR DESCRIPTION
## 📄 Summary
> 

로컬에서 클라이언트와 서버의 origin이 달라 쿠키가 안박히는 것으로 추정, samesite=None 옵션을 설정한다

## 🙋🏻 More
> 
