### PR TITLE
fix: 쿠키 내 domain 설정 추가

### DIFF
--- a/backend/src/main/java/zipgo/auth/support/RefreshTokenCookieProvider.java
+++ b/backend/src/main/java/zipgo/auth/support/RefreshTokenCookieProvider.java
@@ -23,6 +23,7 @@ public class RefreshTokenCookieProvider {
     public ResponseCookie createCookie(String refreshToken) {
         return ResponseCookie.from(REFRESH_TOKEN, refreshToken)
                 .sameSite("None")
+                .domain(".zipgo.pet")
                 .maxAge(Duration.ofMillis(expirationTime))
                 .path(VALID_COOKIE_PATH)
                 .secure(true)
@@ -33,6 +34,7 @@ public class RefreshTokenCookieProvider {
     public ResponseCookie createLogoutCookie() {
         return ResponseCookie.from(REFRESH_TOKEN, LOGOUT_COOKIE_VALUE)
                 .sameSite("None")
+                .domain(".zipgo.pet")
                 .maxAge(LOGOUT_COOKIE_AGE)
                 .build();
     }


### PR DESCRIPTION
## 📄 Summary
> 

.zipgo.pet의 서브도메인 모두 허용하도록 도메인 추가

## 🙋🏻 More
> 
