### PR TITLE
fix: 리뷰요약 동기화 안되는 문제 해결

### DIFF
--- a/frontend/src/hooks/query/review.ts
+++ b/frontend/src/hooks/query/review.ts
@@ -24,7 +24,7 @@ import { FOOD_QUERY_KEY } from './food';
 const QUERY_KEY = {
   reviewItem: 'reviewItem',
   reviewList: (petFoodId: string) => ['reviewList', petFoodId, location.search],
-  reviewSummary: 'reviewSummary',
+  reviewSummary: (petFoodId: string) => ['reviewSummary', petFoodId],
   reviewListMeta: 'reviewListMeta',
 };
 
@@ -62,7 +62,7 @@ export const useAddReviewMutation = () => {
     mutationFn: postReview,
     onSuccess: (_, { petFoodId }) => {
       queryClient.invalidateQueries(QUERY_KEY.reviewList(petFoodId));
-      queryClient.invalidateQueries([QUERY_KEY.reviewSummary]);
+      queryClient.invalidateQueries(QUERY_KEY.reviewSummary(petFoodId));
       queryClient.invalidateQueries(FOOD_QUERY_KEY.foodDetail(petFoodId));
 
       alert('리뷰 작성이 완료되었습니다.');
@@ -82,7 +82,7 @@ export const useEditReviewMutation = () => {
     mutationFn: putReview,
     onSuccess: (_, { petFoodId }) => {
       queryClient.invalidateQueries(QUERY_KEY.reviewList(petFoodId));
-      queryClient.invalidateQueries([QUERY_KEY.reviewSummary]);
+      queryClient.invalidateQueries(QUERY_KEY.reviewSummary(petFoodId));
       queryClient.invalidateQueries(FOOD_QUERY_KEY.foodDetail(petFoodId));
 
       alert('리뷰 수정이 완료되었습니다.');
@@ -101,7 +101,7 @@ export const useRemoveReviewMutation = () => {
     mutationFn: deleteReview,
     onSuccess: (_, { petFoodId }) => {
       queryClient.invalidateQueries(QUERY_KEY.reviewList(petFoodId));
-      queryClient.invalidateQueries([QUERY_KEY.reviewSummary]);
+      queryClient.invalidateQueries(QUERY_KEY.reviewSummary(petFoodId));
       queryClient.invalidateQueries(FOOD_QUERY_KEY.foodDetail(petFoodId));
     },
   });
@@ -111,7 +111,7 @@ export const useRemoveReviewMutation = () => {
 
 export const useReviewSummaryQuery = (payload: Parameter<typeof getReviewSummary>) => {
   const { data, ...restQuery } = useQuery({
-    queryKey: [QUERY_KEY.reviewSummary],
+    queryKey: QUERY_KEY.reviewSummary(payload.petFoodId),
     queryFn: () => getReviewSummary(payload),
   });
 


### PR DESCRIPTION
## 📄 Summary
> 

https://github.com/woowacourse-teams/2023-zipgo/assets/24777828/84d59140-add2-43a6-a568-0b990092fb7b

리뷰 요약 쿼리키에 `petFoodId`를 추가해줘서 모든 상품에 같은(캐싱된) 리뷰요약 정보가 보이는 문제를 해결했어요

## 🙋🏻 More
> 

- close #519
