### PR TITLE
refactor: 식품 이미지 미처 적용 안됐던 lazy loading 적용

### DIFF
--- a/frontend/src/components/@common/LazyImg/LazyImg.tsx
+++ b/frontend/src/components/@common/LazyImg/LazyImg.tsx
@@ -2,7 +2,7 @@ import { ComponentPropsWithoutRef, ForwardedRef, forwardRef, memo, useCallback }
 
 import { useIntersectionObserver } from '@/hooks/@common/useIntersectionObserver';
 
-const LazyImage = forwardRef(
+const LazyImg = forwardRef(
   (props: ComponentPropsWithoutRef<'img'>, ref: ForwardedRef<HTMLImageElement>) => {
     const { src, ...restProps } = props;
 
@@ -28,6 +28,6 @@ const LazyImage = forwardRef(
   },
 );
 
-LazyImage.displayName = 'LazyImage';
+LazyImg.displayName = 'LazyImg';
 
-export default memo(LazyImage);
+export default memo(LazyImg);

--- a/frontend/src/components/@common/LazyImg/LazyImg.tsx
+++ b/frontend/src/components/@common/LazyImg/LazyImg.tsx
@@ -24,7 +24,7 @@ const LazyImg = forwardRef(
     }
 
     // eslint-disable-next-line jsx-a11y/alt-text
-    return <img {...restProps} loading="lazy" ref={callbackRef} />;
+    return <img {...restProps} ref={callbackRef} />;
   },
 );
 

--- a/frontend/src/components/@common/SuspendedImg/SuspendedImg.tsx
+++ b/frontend/src/components/@common/SuspendedImg/SuspendedImg.tsx
@@ -3,7 +3,7 @@ import { ComponentPropsWithoutRef, memo } from 'react';
 
 import { useIntersectionObserver } from '@/hooks/@common/useIntersectionObserver';
 
-import LazyImage from '../LazyImage/LazyImage';
+import LazyImg from '../LazyImg/LazyImg';
 
 interface SuspendedImgProps extends ComponentPropsWithoutRef<'img'> {
   staleTime?: number;
@@ -34,7 +34,7 @@ const SuspendedImg = (props: SuspendedImgProps) => {
   });
 
   if (lazy) {
-    return <LazyImage src={src} ref={targetRef} {...restProps} />;
+    return <LazyImg src={src} ref={targetRef} {...restProps} />;
   }
   // eslint-disable-next-line jsx-a11y/alt-text
   return <img src={src} {...restProps} />;

--- a/frontend/src/components/@common/SuspendedImg/SuspendedImg.tsx
+++ b/frontend/src/components/@common/SuspendedImg/SuspendedImg.tsx
@@ -1,18 +1,18 @@
 import { useQuery } from '@tanstack/react-query';
-import { ComponentPropsWithoutRef, ComponentPropsWithRef, useEffect } from 'react';
+import { ComponentPropsWithoutRef, memo } from 'react';
 
 import { useIntersectionObserver } from '@/hooks/@common/useIntersectionObserver';
+
+import LazyImage from '../LazyImage/LazyImage';
 
 interface SuspendedImgProps extends ComponentPropsWithoutRef<'img'> {
   staleTime?: number;
   cacheTime?: number;
-  enabled?: boolean;
   lazy?: boolean;
 }
 
-// eslint-disable-next-line react/display-name
 const SuspendedImg = (props: SuspendedImgProps) => {
-  const { src, cacheTime, staleTime, enabled, lazy, ...restProps } = props;
+  const { src, cacheTime, staleTime, lazy, ...restProps } = props;
 
   const img = new Image();
 
@@ -20,36 +20,24 @@ const SuspendedImg = (props: SuspendedImgProps) => {
     observerOptions: { threshold: 0.1 },
   });
 
-  const lazyOptions: ComponentPropsWithRef<'img'> & { 'data-src'?: string } = {
-    loading: 'lazy',
-    ref: targetRef,
-    'data-src': src,
-  };
-
   useQuery({
     queryKey: [src],
     queryFn: () =>
       new Promise(resolve => {
         img.onload = resolve;
         img.onerror = resolve;
-
         img.src = src!;
       }),
     ...(staleTime == null ? {} : { staleTime }),
     ...(cacheTime == null ? {} : { cacheTime }),
-    enabled: enabled && Boolean(src),
+    enabled: lazy ? isIntersected : true,
   });
 
-  useEffect(() => {
-    if (!targetRef.current) return;
-
-    if ('loading' in HTMLImageElement.prototype || isIntersected) {
-      targetRef.current.src = String(targetRef.current.dataset.src);
-    }
-  }, [isIntersected]);
-
+  if (lazy) {
+    return <LazyImage src={src} ref={targetRef} {...restProps} />;
+  }
   // eslint-disable-next-line jsx-a11y/alt-text
-  return <img {...restProps} {...(lazy ? lazyOptions : { src })} />;
+  return <img src={src} {...restProps} />;
 };
 
-export default SuspendedImg;
+export default memo(SuspendedImg);

--- a/frontend/src/components/Food/FoodItem/FoodItem.tsx
+++ b/frontend/src/components/Food/FoodItem/FoodItem.tsx
@@ -13,7 +13,7 @@ const FoodItem = (foodItemProps: FoodItemProps) => {
   return (
     <FoodItemWrapper to={`pet-food/${id}`}>
       <FoodImageWrapper>
-        <FoodImage src={imageUrl} alt="Food image" />
+        <FoodImage src={imageUrl} alt="Food image" lazy />
       </FoodImageWrapper>
       <BrandName>{brandName}</BrandName>
       <FoodName>{foodName}</FoodName>

--- a/frontend/src/hooks/@common/useIntersectionObserver.ts
+++ b/frontend/src/hooks/@common/useIntersectionObserver.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useCallback, useEffect, useRef, useState } from 'react';
+import { MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 interface UseIntersectionObserverOptions<T extends HTMLElement> {
   ref?: MutableRefObject<T | null>;
@@ -8,7 +8,7 @@ interface UseIntersectionObserverOptions<T extends HTMLElement> {
 export const useIntersectionObserver = <T extends HTMLElement>(
   options?: UseIntersectionObserverOptions<T>,
 ) => {
-  const localRef = useRef<T>(null);
+  const localRef: MutableRefObject<T | null> = useRef<T>(null);
 
   const observerRef = useRef<IntersectionObserver | null>(null);
 


### PR DESCRIPTION
## 📄 Summary
- [x] 식품 이미지에 빠져있던 lazy 속성 추가
- [x] `SuspendImg`의 lazy loading 기능을 `LazyImg`를 활용하여 구현
- [x] `LazyImg`가 callbackRef를 받을 수 있도록 보강
- [x] 이미지 중복 다운로드 방지

## 🙋🏻 More
> - close #528 
