### PR TITLE
feat: 견종 목록 조회시 로컬 캐시 적용

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
@@ -69,6 +70,8 @@ dependencies {
 
     implementation 'software.amazon.awssdk:s3:2.20.121'
     implementation 'software.amazon.awssdk:url-connection-client:2.20.121'
+
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.3.1'

--- a/backend/src/main/java/zipgo/admin/application/AdminService.java
+++ b/backend/src/main/java/zipgo/admin/application/AdminService.java
@@ -2,6 +2,7 @@ package zipgo.admin.application;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import zipgo.admin.dto.BrandCreateRequest;
@@ -11,6 +12,10 @@ import zipgo.admin.dto.PetFoodUpdateRequest;
 import zipgo.admin.dto.PrimaryIngredientCreateRequest;
 import zipgo.brand.domain.Brand;
 import zipgo.brand.domain.repository.BrandRepository;
+import zipgo.pet.domain.Breed;
+import zipgo.pet.domain.PetSize;
+import zipgo.pet.domain.repository.BreedRepository;
+import zipgo.pet.domain.repository.PetSizeRepository;
 import zipgo.petfood.domain.Functionality;
 import zipgo.petfood.domain.PetFood;
 import zipgo.petfood.domain.PetFoodFunctionality;
@@ -31,6 +36,8 @@ public class AdminService {
     private final FunctionalityRepository functionalityRepository;
     private final PrimaryIngredientRepository primaryIngredientRepository;
     private final PetFoodRepository petFoodRepository;
+    private final BreedRepository breedRepository;
+    private final PetSizeRepository petSizeRepository;
 
     public Long createBrand(BrandCreateRequest request, String imageUrl) {
         Brand brand = request.toEntity(imageUrl);
@@ -149,4 +156,10 @@ public class AdminService {
         petFoodRepository.deleteById(petFoodId);
     }
 
+    @CacheEvict(cacheNames = "breeds", key = "'allBreeds'")
+    public Long createBreed(Long petSizeId, String breedName) {
+        PetSize petSize = petSizeRepository.getReferenceById(petSizeId);
+        Breed breed = breedRepository.save(Breed.builder().name(breedName).petSize(petSize).build());
+        return breed.getId();
+    }
 }

--- a/backend/src/main/java/zipgo/admin/dto/BreedCreateRequest.java
+++ b/backend/src/main/java/zipgo/admin/dto/BreedCreateRequest.java
@@ -1,0 +1,8 @@
+package zipgo.admin.dto;
+
+public record BreedCreateRequest(
+        Long petSizeId,
+        String breedName
+) {
+
+}

--- a/backend/src/main/java/zipgo/admin/presentation/AdminController.java
+++ b/backend/src/main/java/zipgo/admin/presentation/AdminController.java
@@ -18,6 +18,7 @@ import zipgo.admin.application.AdminQueryService;
 import zipgo.admin.application.AdminService;
 import zipgo.admin.dto.BrandCreateRequest;
 import zipgo.admin.dto.BrandSelectResponse;
+import zipgo.admin.dto.BreedCreateRequest;
 import zipgo.admin.dto.FunctionalityCreateRequest;
 import zipgo.admin.dto.FunctionalitySelectResponse;
 import zipgo.admin.dto.PetFoodCreateRequest;
@@ -125,6 +126,14 @@ public class AdminController {
     public ResponseEntity<Void> deletePetFood(@PathVariable Long petFoodId) {
         adminService.deletePetFood(petFoodId);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/breeds")
+    public ResponseEntity<Long> createBreeds(
+            @RequestBody BreedCreateRequest breedCreateRequest
+    ) {
+        Long breedId = adminService.createBreed(breedCreateRequest.petSizeId(), breedCreateRequest.breedName());
+        return ResponseEntity.created(URI.create("/breeds/" + breedId)).build();
     }
 
 }

--- a/backend/src/main/java/zipgo/common/cache/CacheType.java
+++ b/backend/src/main/java/zipgo/common/cache/CacheType.java
@@ -1,0 +1,16 @@
+package zipgo.common.cache;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CacheType {
+
+    BREEDS("breeds", 1),
+    ;
+
+    private final String name;
+    private final int maxSize;
+
+}

--- a/backend/src/main/java/zipgo/common/config/CacheConfig.java
+++ b/backend/src/main/java/zipgo/common/config/CacheConfig.java
@@ -1,0 +1,39 @@
+package zipgo.common.config;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import zipgo.common.cache.CacheType;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager cacheManager = new SimpleCacheManager();
+        cacheManager.setCaches(caches());
+        return cacheManager;
+    }
+
+    private List<CaffeineCache> caches() {
+        return Arrays.stream(CacheType.values())
+                .map(cacheType -> new CaffeineCache(cacheType.getName(), cache(cacheType)))
+                .toList();
+    }
+
+    private Cache<Object, Object> cache(CacheType cacheType) {
+        return Caffeine.newBuilder()
+                .maximumSize(cacheType.getMaxSize())
+                .build();
+    }
+
+}

--- a/backend/src/main/java/zipgo/pet/application/PetQueryService.java
+++ b/backend/src/main/java/zipgo/pet/application/PetQueryService.java
@@ -31,7 +31,7 @@ public class PetQueryService {
     }
 
     public List<Breed> readBreeds() {
-        Breeds breeds = Breeds.from(breedRepository.findAll());
+        Breeds breeds = Breeds.from(breedRepository.findAllBreeds());
         return breeds.getOrderedBreeds();
     }
 

--- a/backend/src/main/java/zipgo/pet/domain/repository/BreedRepository.java
+++ b/backend/src/main/java/zipgo/pet/domain/repository/BreedRepository.java
@@ -2,12 +2,19 @@ package zipgo.pet.domain.repository;
 
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import zipgo.pet.domain.Breed;
 import zipgo.pet.domain.PetSize;
 import zipgo.pet.exception.BreedsNotFoundException;
 
 public interface BreedRepository extends JpaRepository<Breed, Long> {
+
+    @Cacheable(cacheNames = "breeds", key = "'allBreeds'")
+    default List<Breed> findAllBreeds() {
+        return findAll();
+    }
 
     Optional<Breed> findByPetSizeAndName(PetSize petSize, String name);
 

--- a/backend/src/main/java/zipgo/review/application/ReviewQueryService.java
+++ b/backend/src/main/java/zipgo/review/application/ReviewQueryService.java
@@ -116,7 +116,7 @@ public class ReviewQueryService {
     }
 
     private List<Metadata> findAllBreeds() {
-        Breeds breeds = Breeds.from(breedRepository.findAll());
+        Breeds breeds = Breeds.from(breedRepository.findAllBreeds());
         return breeds.getOrderedBreeds().stream()
                 .map(breed -> new Metadata(breed.getId(), breed.getName()))
                 .toList();


### PR DESCRIPTION
## 📄 Summary
> #532 로컬 캐시 적용

### 세 줄 요약
1. breedRepository.findAll()에 로컬 캐싱 적용함
2. admin에 견종 등록 API 추가함
3.  (2) 번 통해 견종 추가되면 캐시 깨짐

## 인트로 

견종 목록 같은 경우 추가될 일이 극히 드물겠죠
리뷰 조회나 식품 조회같이 필터링이 필요한 경우도 아니구요
그래서, 로컬 **캐싱을 적용해보았습니다**

## 추가된 의존성

[스프링 공식문서](https://docs.spring.io/spring-framework/reference/integration/cache.html) 를 보면, CacheManager라는 인터페이스를 제공합니다.  이 친구를 통해 WAS 레벨에서의 캐싱을 적용할 수 있어요!

구현체인 라이브러리는 caffeine이라는 친구를 사용했습니다
크게 구관인 [Enacache](https://github.com/ehcache/ehcache3)와 요즘 대세 [Caffeine](https://github.com/ben-manes/caffeine) 이 두 친구가 있는데, Enacahe는 xml 방식으로 사용해야하고, 스타수도 10배씩이나 차이나서 caffeine으로 선택했습니다

## 아니 그래서 적용은 어떻게 되냐?

[CacheConfig](https://github.com/woowacourse-teams/2023-zipgo/blob/feat/%23532/backend/src/main/java/zipgo/common/config/CacheConfig.java) 설정을 통해, CacheManager와  Caffeine을 Bean으로 등록했어요

`@CacheEvict(cacheNames = "breeds", key = "'allBreeds'")` 
위 어노테이션을 붙인 메서드가 실행되면 캐시가 사라지는데요,
어드민에 견종 추가 API를 만든 후 해당 어노테이션을 붙여줬습니다

`@Cacheable(cacheNames = "breeds", key = "'allBreeds'")`
위 어노테이션을 붙인 메서드가 실행되면 캐시가 적용되는데요,
 breedRepository의 findAll()을 감싼 `findAllBreeds()` 메서드 위에 붙여줬습니다

## 캐싱 잘 되나요?
<img width="868" alt="image" src="https://github.com/woowacourse-teams/2023-zipgo/assets/73161212/23e600de-7837-4b18-81e5-327b9a125832">
위와같이 첫 요청시에만 쿼리가 나가고, 두번째 요청부터는 캐시가 적용 돼 쿼리가 안나가는 걸 확인할 수 있습니다 😃

## 결과

select * from breeds 쿼리를 사용하는 두 개의 API를 대상으로
견종 300개 넣은 로컬에서 실험해보았습니다

[GET] /pets/breeds는
200ms -> 20~30ms
![image](https://github.com/woowacourse-teams/2023-zipgo/assets/73161212/a729e0b6-ebd8-4d42-8b8e-c9be366ab5fb)


[GET] /reviews/metadata는
200ms -> 30~40ms
![image](https://github.com/woowacourse-teams/2023-zipgo/assets/73161212/5837aa38-9662-4d70-b963-667ec34b1815)


로 유의미한 차이를 확인할 수 있었습니다🙂