### PR TITLE
refactor: Cache ExpireTime 설정

### DIFF
--- a/backend/src/main/java/zipgo/common/cache/CacheType.java
+++ b/backend/src/main/java/zipgo/common/cache/CacheType.java
@@ -7,10 +7,11 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum CacheType {
 
-    BREEDS("breeds", 1),
+    BREEDS("breeds", 1, 10),
     ;
 
     private final String name;
     private final int maxSize;
+    private final long expireTime;
 
 }

--- a/backend/src/main/java/zipgo/common/config/CacheConfig.java
+++ b/backend/src/main/java/zipgo/common/config/CacheConfig.java
@@ -1,8 +1,5 @@
 package zipgo.common.config;
 
-import java.util.Arrays;
-import java.util.List;
-
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import org.springframework.cache.CacheManager;
@@ -12,6 +9,10 @@ import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import zipgo.common.cache.CacheType;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @EnableCaching
 @Configuration
@@ -33,6 +34,7 @@ public class CacheConfig {
     private Cache<Object, Object> cache(CacheType cacheType) {
         return Caffeine.newBuilder()
                 .maximumSize(cacheType.getMaxSize())
+                .expireAfterWrite(cacheType.getExpireTime(), TimeUnit.SECONDS)
                 .build();
     }
 


### PR DESCRIPTION
## 📄 Summary
> #534

## 🙋🏻 More
> 단위는 초(Second)이고, 기본 10초로 설정했습니다.
캐시에 데이터가 생성된 후 또는 해당 값을 가장 최근에 바뀐 후 특정 기간이 지나면 각 항목이 캐시에서 자동으로 제거됩니다.
10초로 한 이유는.... 그렇게 많지도 적지도 않아서..? 
그런데 Guava 캐시 라이브러리처럼 데이터베이스에 데이터가 변경될 때 캐시까지 적용해주는 기능이 존재하지 않기 때문에 기존 캐시에 있는 데이터를 바로 삭제하는게 좋을 것 같기도 합니당
