### PR TITLE
fix: 반려동물 프로필 이미지 추가, 수정 시 이미지 업로드 도중 폼 제출 못하도록 수정

### DIFF
--- a/frontend/src/components/PetProfile/PetInfoInForm.tsx
+++ b/frontend/src/components/PetProfile/PetInfoInForm.tsx
@@ -5,32 +5,51 @@ import CameraIcon from '@/assets/svg/camera_icon.svg';
 import { useImageUpload } from '@/hooks/@common/useImageUpload';
 import { PetProfile } from '@/types/petProfile/client';
 
+import LoadingSpinner from '../@common/LoadingSpinner/LoadingSpinner';
 import { getGenderImage, getPetAge } from './PetItem';
 
 interface PetInfoInFormProps {
   petItem: PetProfile;
   onChangeImage: (imageUrl: string) => void;
+  updateIsProcessingImage: (isProcessing: boolean) => void;
 }
 
 const PetInfoInForm = (petInfoInFormProps: PetInfoInFormProps) => {
-  const { petItem, onChangeImage } = petInfoInFormProps;
-  const { previewImage, imageUrl, uploadImage } = useImageUpload();
+  const { petItem, onChangeImage, updateIsProcessingImage } = petInfoInFormProps;
+  const {
+    imageUrl,
+    previewImage,
+    compressionPercentage,
+    isImageBeingCompressed,
+    isImageBeingUploaded,
+    uploadCompressedImage,
+  } = useImageUpload();
 
   useEffect(() => {
     if (imageUrl) onChangeImage(imageUrl);
   }, [imageUrl]);
 
+  useEffect(() => {
+    updateIsProcessingImage(isImageBeingCompressed || isImageBeingUploaded);
+  }, [isImageBeingCompressed, isImageBeingUploaded, updateIsProcessingImage]);
+
   return (
     <PetInfoContainer>
       <PetImageAndDetail>
         <ImageUploadLabel>
-          <input type="file" accept="image/*" onChange={uploadImage} />
+          <input type="file" accept="image/*" onChange={uploadCompressedImage} />
           <PetImageWrapper>
+            {isImageBeingCompressed && (
+              <ProgressTracker>
+                <p>이미지 압축 중({compressionPercentage}%)</p>
+              </ProgressTracker>
+            )}
             <PetImage src={previewImage || petItem.imageUrl} alt={petItem.name} />
           </PetImageWrapper>
           <CameraIconWrapper>
             <CameraImage src={CameraIcon} alt="" />
           </CameraIconWrapper>
+          {isImageBeingUploaded && <LoadingSpinner />}
         </ImageUploadLabel>
         <div>
           <GenderAndName>
@@ -68,7 +87,6 @@ const ImageUploadLabel = styled.label`
   height: 10rem;
 
   background-color: ${({ theme }) => theme.color.grey200};
-  border: 1px solid ${({ theme }) => theme.color.grey300};
   border-radius: 50%;
 
   & > input {
@@ -78,6 +96,7 @@ const ImageUploadLabel = styled.label`
 
 const CameraIconWrapper = styled.div`
   position: absolute;
+  z-index: 200;
   right: 0;
   bottom: 0;
 
@@ -142,7 +161,31 @@ const PetImageWrapper = styled.div`
   height: 10rem;
 
   background-color: ${({ theme }) => theme.color.white};
+  border: 1px solid ${({ theme }) => theme.color.grey300};
   border-radius: 50%;
+`;
+
+const ProgressTracker = styled.div`
+  position: absolute;
+  z-index: 100;
+  top: 0;
+  left: 0;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: inherit;
+  height: inherit;
+
+  opacity: 0.7;
+  background-color: ${({ theme }) => theme.color.grey200};
+
+  & > p {
+    font-size: 1.2rem;
+
+    opacity: 1;
+  }
 `;
 
 const PetImage = styled.img`

--- a/frontend/src/components/PetProfile/PetProfileEditionForm/PetProfileEditionForm.tsx
+++ b/frontend/src/components/PetProfile/PetProfileEditionForm/PetProfileEditionForm.tsx
@@ -19,6 +19,8 @@ const PetProfileEditionForm = () => {
     isValidNameInput,
     isValidAgeSelect,
     isValidWeightInput,
+    isProcessingImage,
+    updateIsProcessingImage,
     onChangeName,
     onChangeAge,
     onChangeWeight,
@@ -37,6 +39,7 @@ const PetProfileEditionForm = () => {
               <PetInfoInForm
                 petItem={{ ...pet, weight: Number(pet.weight) }}
                 onChangeImage={onChangeImage}
+                updateIsProcessingImage={updateIsProcessingImage}
               />
             </PetInfoWrapper>
 
@@ -108,7 +111,7 @@ const PetProfileEditionForm = () => {
               type="button"
               $isEditButton
               onClick={onSubmitNewPetProfile}
-              disabled={!isValidForm}
+              disabled={!isValidForm || isProcessingImage}
             >
               <EditIconImage src={EditIconLight} alt="" />
               수정

--- a/frontend/src/constants/petProfile.ts
+++ b/frontend/src/constants/petProfile.ts
@@ -32,7 +32,7 @@ export const PET_ERROR_MESSAGE = {
   INVALID_WEIGHT: '몸무게는 0kg초과, 100kg이하 소수점 첫째짜리까지 입력이 가능합니다.',
 } as const;
 
-export const PET_PROFILE_IMAGE_MAX_SIZE = 200;
+export const PET_PROFILE_IMAGE_MAX_SIZE = 1000;
 export const PET_PROFILE_IMAGE_COMPRESSION_OPTION: Options = {
   maxSizeMB: 1,
   maxWidthOrHeight: PET_PROFILE_IMAGE_MAX_SIZE,

--- a/frontend/src/hooks/@common/useImageUpload.ts
+++ b/frontend/src/hooks/@common/useImageUpload.ts
@@ -2,22 +2,25 @@ import imageCompression from 'browser-image-compression';
 import { ChangeEvent, useState } from 'react';
 
 import { PET_PROFILE_IMAGE_COMPRESSION_OPTION } from '@/constants/petProfile';
+import { useToast } from '@/context/Toast/ToastContext';
 import { useUploadImageMutation } from '@/hooks/query/image';
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB;
 
 export const useImageUpload = () => {
+  const { toast } = useToast();
+  const { uploadImageMutation } = useUploadImageMutation();
   const [previewImage, setPreviewImage] = useState('');
   const [imageUrl, setImageUrl] = useState('');
-  const { uploadImageMutation } = useUploadImageMutation();
+  const [compressionPercentage, setCompressionPercentage] = useState(-1);
+  const isImageBeingCompressed = compressionPercentage > -1 && compressionPercentage < 100;
 
-  const uploadImage = async (e: ChangeEvent<HTMLInputElement>) => {
+  const uploadCompressedImage = async (e: ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files) return;
 
     const originalImageFile = e.target.files[0];
 
     if (!originalImageFile) return;
-
     if (originalImageFile.size > MAX_FILE_SIZE) {
       e.target.value = '';
       alert('이미지 크기가 너무 큽니다. 5MB 이하의 이미지를 업로드해주세요.');
@@ -25,20 +28,23 @@ export const useImageUpload = () => {
       return;
     }
 
-    const compressedImageBlob = await imageCompression(
-      originalImageFile,
-      PET_PROFILE_IMAGE_COMPRESSION_OPTION,
-    );
+    setCompressionPercentage(0);
+    setPreviewImage(URL.createObjectURL(originalImageFile));
 
     const imageUploadFormData = new FormData();
+    const compressedImageBlob = await imageCompression(originalImageFile, {
+      ...PET_PROFILE_IMAGE_COMPRESSION_OPTION,
+      onProgress: progress => setCompressionPercentage(progress),
+    });
+
+    setCompressionPercentage(-1);
 
     imageUploadFormData.append('image', compressedImageBlob);
 
     uploadImageMutation.uploadImage({ imageFile: imageUploadFormData }).then(data => {
       setImageUrl(data.imageUrl);
+      toast.success('이미지 업로드가 완료됐어요!');
     });
-
-    setPreviewImage(URL.createObjectURL(compressedImageBlob));
   };
 
   const deletePreviewImage = () => {
@@ -47,9 +53,12 @@ export const useImageUpload = () => {
   };
 
   return {
-    previewImage,
     imageUrl,
-    uploadImage,
+    previewImage,
+    compressionPercentage,
+    isImageBeingUploaded: uploadImageMutation.isLoading,
+    isImageBeingCompressed,
+    uploadCompressedImage,
     deletePreviewImage,
   };
 };

--- a/frontend/src/hooks/petProfile/usePetProfileEdition.ts
+++ b/frontend/src/hooks/petProfile/usePetProfileEdition.ts
@@ -28,6 +28,7 @@ export const usePetProfileEdition = () => {
   const { removePetMutation } = useRemovePetMutation();
 
   const [pet, setPet] = useState<PetInput | undefined>(petItem);
+  const [isProcessingImage, setIsProcessingImage] = useState(false);
   const [isValidNameInput, setIsValidNameInput] = useState(true);
   const [isValidAgeSelect, setIsValidAgeSelect] = useState(true);
   const [isValidWeightInput, setIsValidWeightInput] = useState(true);
@@ -36,6 +37,8 @@ export const usePetProfileEdition = () => {
   useEffect(() => {
     setPet(petItem);
   }, [petItem]);
+
+  const updateIsProcessingImage = (isProcessing: boolean) => setIsProcessingImage(isProcessing);
 
   const onChangeName = (e: ChangeEvent<HTMLInputElement>) => {
     const petName = e.target.value;
@@ -125,6 +128,8 @@ export const usePetProfileEdition = () => {
     isValidNameInput,
     isValidAgeSelect,
     isValidWeightInput,
+    isProcessingImage,
+    updateIsProcessingImage,
     onChangeName,
     onChangeAge,
     onChangeWeight,

--- a/frontend/src/pages/PetProfile/PetProfileAddition/PetProfileImageAddition.tsx
+++ b/frontend/src/pages/PetProfile/PetProfileAddition/PetProfileImageAddition.tsx
@@ -5,16 +5,16 @@ import { usePetProfileAddition } from '@/hooks/petProfile/usePetProfileAddition'
 import { getTopicParticle } from '@/utils/getTopicParticle';
 
 const PetProfileImageAddition = () => {
-  const { petProfile, onSubmitPetProfile } = usePetProfileAddition();
+  const { petProfile, isValidInput, setIsValidInput, onSubmitPetProfile } = usePetProfileAddition();
 
   return (
     <Container>
       <PetName>{petProfile.name}</PetName>
       <Title>{`${getTopicParticle(petProfile.name)} 어떤 모습인가요?`}</Title>
       <Content>
-        <PetProfileImageUploader />
+        <PetProfileImageUploader updateIsValid={setIsValidInput} />
       </Content>
-      <SubmitButton type="button" onClick={onSubmitPetProfile}>
+      <SubmitButton type="button" disabled={!isValidInput} onClick={onSubmitPetProfile}>
         등록하기
       </SubmitButton>
     </Container>


### PR DESCRIPTION
## 📄 Summary
### 문제점
https://github.com/woowacourse-teams/2023-zipgo/assets/24777828/2b8d6bda-5247-49b9-80c0-e88df5310c0e

반려동물 프로필 이미지를 추가하거나 수정할 때 아래와 같은 단계를 거칩니다.
- 이미지 파일 압축 > 압축된 이미지 파일 서버에 업로드 > 서버로부터 이미지 URL을 응답받음

네트워크 상태를 slow 3g로 설정한 후 테스트해보니, 이미지가 업로드 되기 전에 등록 버튼을 누르면 프로필 이미지가 제대로 등록되지 않더라구요!

### 주요 작업내용
- 압축 중인 경우 > 압축 진행률을 보여줍니다.
- 업로드 중인 경우 > 로딩 스피너를 보여줍니다.
- 이미지 압축 중이거나 업로드 중인 경우 > 버튼을 비활성화합니다.

### 기타 작업내용
- 반려동물 이미지 최대 가로, 세로 너비를 `200 -> 1000px`로 수정(압축 라이브러리 설정 중 `maxWidthOrHeight` 값 변경)
  - 문제: 만약 `1:9` 비율의 이미지라고 하면 가로 약`22px`, 세로 `200px`이 되는데 이 이미지를 프로필 사이즈(`55x55`)로 늘리게 되면 이미지가 심하게 깨짐
  - 해결: `110px`(55x2)을 기준으로 하면 `990px`을 최대 너비로 설정하면 됨 -> 조금 더 넉넉하게 `1000px`로 설정

### 실행화면(5MB 이미지 업로드 테스트)

https://github.com/woowacourse-teams/2023-zipgo/assets/24777828/f564503d-3282-4504-a12c-9e6b9d1a11b5

https://github.com/woowacourse-teams/2023-zipgo/assets/24777828/07db6ba6-1d2b-47eb-95b0-6f34119e6e4a



## 🙋🏻 More
> 

- close #537 
