### PR TITLE
feat: 반려동물 식품 로컬 캐시 적용 

### DIFF
--- a/backend/src/main/java/zipgo/admin/application/AdminService.java
+++ b/backend/src/main/java/zipgo/admin/application/AdminService.java
@@ -54,6 +54,7 @@ public class AdminService {
         return primaryIngredientRepository.save(primaryIngredient).getId();
     }
 
+    @CacheEvict(cacheNames = "petFoods", keyGenerator = "customKeyGenerator")
     public Long createPetFood(PetFoodCreateRequest request, String imageUrl) {
         Brand brand = brandRepository.getById(request.brandId());
         PetFood petFood = request.toEntity(brand, imageUrl);

--- a/backend/src/main/java/zipgo/common/cache/CacheType.java
+++ b/backend/src/main/java/zipgo/common/cache/CacheType.java
@@ -1,16 +1,22 @@
 package zipgo.common.cache;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public enum CacheType {
 
-    BREEDS("breeds", 1),
+    BREEDS("breeds"),
+    PET_FOODS("petFoods")
     ;
+
+    CacheType(String name) {
+        this.name = name;
+        this.maxSize = 10000;
+        this.expireTime = 3000;
+    }
 
     private final String name;
     private final int maxSize;
+    private final long expireTime;
 
 }

--- a/backend/src/main/java/zipgo/common/cache/CustomKeyGenerator.java
+++ b/backend/src/main/java/zipgo/common/cache/CustomKeyGenerator.java
@@ -1,0 +1,14 @@
+package zipgo.common.cache;
+
+import org.springframework.cache.interceptor.KeyGenerator;
+import org.springframework.util.StringUtils;
+
+import java.lang.reflect.Method;
+
+public class CustomKeyGenerator implements KeyGenerator {
+
+    @Override
+    public Object generate(Object target, Method method, Object... params) {
+        return StringUtils.arrayToDelimitedString(params, "_");
+    }
+}

--- a/backend/src/main/java/zipgo/common/config/CacheConfig.java
+++ b/backend/src/main/java/zipgo/common/config/CacheConfig.java
@@ -2,16 +2,19 @@ package zipgo.common.config;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.cache.support.SimpleCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import zipgo.common.cache.CacheType;
+import zipgo.common.cache.CustomKeyGenerator;
 
 @EnableCaching
 @Configuration
@@ -33,7 +36,13 @@ public class CacheConfig {
     private Cache<Object, Object> cache(CacheType cacheType) {
         return Caffeine.newBuilder()
                 .maximumSize(cacheType.getMaxSize())
+                .expireAfterWrite(cacheType.getExpireTime(), TimeUnit.SECONDS)
                 .build();
     }
 
+
+    @Bean("customKeyGenerator")
+    public KeyGenerator keyGenerator() {
+        return new CustomKeyGenerator();
+    }
 }

--- a/backend/src/main/java/zipgo/petfood/application/PetFoodQueryService.java
+++ b/backend/src/main/java/zipgo/petfood/application/PetFoodQueryService.java
@@ -2,6 +2,7 @@ package zipgo.petfood.application;
 
 import datadog.trace.api.Trace;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import zipgo.brand.domain.Brand;
@@ -31,6 +32,7 @@ public class PetFoodQueryService {
     private final FunctionalityRepository functionalityRepository;
     private final PrimaryIngredientRepository primaryIngredientRepository;
 
+    @Cacheable(cacheNames = "petFoods", keyGenerator = "customKeyGenerator")
     public GetPetFoodsResponse getPetFoodsByFilters(FilterRequest filterDto, Long lastPetFoodId, int size) {
         return GetPetFoodsResponse.from(
                 getPetFoodsCount(filterDto),

--- a/backend/src/main/java/zipgo/petfood/infra/persist/PetFoodQueryRepositoryImpl.java
+++ b/backend/src/main/java/zipgo/petfood/infra/persist/PetFoodQueryRepositoryImpl.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 
 import static zipgo.brand.domain.QBrand.brand;
 import static zipgo.petfood.domain.QPetFood.petFood;
-import static zipgo.petfood.domain.QPetFoodFunctionality.petFoodFunctionality;
 import static zipgo.petfood.domain.QPetFoodPrimaryIngredient.petFoodPrimaryIngredient;
 import static zipgo.petfood.domain.QPrimaryIngredient.primaryIngredient;
 
@@ -45,8 +44,6 @@ public class PetFoodQueryRepositoryImpl implements PetFoodQueryRepository {
                 )
                 .from(petFood)
                 .innerJoin(petFood.brand, brand)
-                .innerJoin(petFood.petFoodPrimaryIngredients, petFoodPrimaryIngredient)
-                .innerJoin(petFood.petFoodFunctionalities, petFoodFunctionality)
                 .where(
                         isLessThan(lastPetFoodId),
                         isContainBrand(brandsName),
@@ -55,7 +52,6 @@ public class PetFoodQueryRepositoryImpl implements PetFoodQueryRepository {
                         isContainFunctionalities(functionalityList)
                 )
                 .orderBy(petFood.id.desc())
-                .groupBy(petFood.id)
                 .limit(size)
                 .fetch();
     }
@@ -117,8 +113,6 @@ public class PetFoodQueryRepositoryImpl implements PetFoodQueryRepository {
                 .select(petFood.id.countDistinct())
                 .from(petFood)
                 .join(petFood.brand, brand)
-                .join(petFood.petFoodPrimaryIngredients, petFoodPrimaryIngredient)
-                .join(petFood.petFoodFunctionalities, petFoodFunctionality)
                 .where(
                         isContainBrand(brandsName),
                         isMeetStandardCondition(standards),


### PR DESCRIPTION
## 📄 Summary
- closed #487
- closed #534
- closed #536

## Done

- PetFoodQueryRepositoryImpl 쿼리 불필요한 join 및 group by 제거
- 반려동물 식품 캐싱 적용 및 테스트

### 반려동물 식품 캐싱 적용

반려동물 식품 같은 경우도 조회는 매우 자주 일어나지만 수정, 삽입이 거의 일어나지 않기 때문에 캐싱하기에 적합하다고 생각합니다. 그래서 적용해보았는데요.

![image](https://github.com/woowacourse-teams/2023-zipgo/assets/76938931/966c3148-6f00-4421-bd8f-0c857548e226)

캐시가 Hit 되는 경우 쿼리가 2번에서 0번

![image](https://github.com/woowacourse-teams/2023-zipgo/assets/76938931/61e61ae9-9c32-4baf-8c6c-2f7dfd4736d1)

![image](https://github.com/woowacourse-teams/2023-zipgo/assets/76938931/5b549742-c48e-45da-ac33-912e2904e113)

시간도 2초에서 0.01초로 개선되었습니다. 
(필터링 API는 현재 String으로 받고 있는 파라미터가 있어서 데이터가 많으면 불필요한 조인 테이블이 발생해서 2초정도 걸리는데요. 이걸 Id로 받도록 고치면 애초에 2초가 아니고 0.2~5초 대로 감소하긴 합니다. 하지만 그렇게 되는경우 클라이언트쪽도 고쳐야되기 때문에 제외, 이 경우에도 0.5 -> 0.01이기 때문에 유의미)

해당 @Cacheable의 key 같은 경우 기본키 전략이 아닌 customKeyGenerator를 따로 만들어서 사용했습니다.  스프링은 SimpleKeyGenerator에 의해 Cache Key를 생성하는데요.

<img width="469" alt="image" src="https://github.com/woowacourse-teams/2023-zipgo/assets/76938931/7f715ead-a965-4b23-87a6-8dc64e9f93f0">

<img width="547" alt="image" src="https://github.com/woowacourse-teams/2023-zipgo/assets/76938931/0c038c10-9652-434e-ae31-8b478147b60d">

<img width="581" alt="image" src="https://github.com/woowacourse-teams/2023-zipgo/assets/76938931/4a9d742c-0cd5-4a84-86e7-687be6ab4440">

- 파라미터가 없는 경우 empty
- 1개인 경우 해당 파라미터
- 여러개 인경우 모든 파라미터의 hashcode 값을 이용해 하나의 복합키로 만듭니다.

반려동물 식품 필터링 API에는 여러가지 파라미터들이 들어오는데요. 기본키로 생성 하는 경우 위의 설명대로 복합키로 만들어 key로 사용하기 때문에 테스트할 때 캐시를 어떻게 꺼내 사용할 방법을 찾지 못해서 결국 customGenerator를 등록해서 사용했습니다. 테스트 할 때 더 좋은 방법이 있으면 말씀해주세요!

## 🙋🏻 More
>  현재 최대값을 10000개 만료 시간을 3초로 임시로 설정해놨는데 얼마로 하는게 좋을지 의논해보면 좋을 것 같습니다~

- maximumSize: 캐시에 포함할 수 있는 최대 엔트리 수를 지정합니다.
- expireAfterWrite: 항목이 생성된 후 또는 해당 값을 가장 최근에 바뀐 후 특정 기간이 지나면 각 항목이 캐시에서 자동으로 제거되도록 지정합니다.
