### PR TITLE
fix: added api server domain to allowed origins

### DIFF
--- a/backend/src/main/java/zipgo/common/config/WebConfig.java
+++ b/backend/src/main/java/zipgo/common/config/WebConfig.java
@@ -1,7 +1,6 @@
 package zipgo.common.config;
 
 import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -27,6 +26,7 @@ public class WebConfig implements WebMvcConfigurer {
     private static final String DEV_SERVER_DOMAIN = "https://dev.zipgo.pet";
     private static final String FRONTEND_LOCALHOST = "http://localhost:3000";
     private static final String HTTPS_FRONTEND_LOCALHOST = "https://localhost:3000";
+    private static final String API_SERVER_DOMAIN = "https://api.zipgo.pet";
 
     private final AuthInterceptor authInterceptor;
     private final LoggingInterceptor loggingInterceptor;
@@ -40,7 +40,8 @@ public class WebConfig implements WebMvcConfigurer {
                         MAIN_SERVER_DOMAIN,
                         DEV_SERVER_DOMAIN,
                         FRONTEND_LOCALHOST,
-                        HTTPS_FRONTEND_LOCALHOST
+                        HTTPS_FRONTEND_LOCALHOST,
+                        API_SERVER_DOMAIN
                 )
                 .allowCredentials(true)
                 .exposedHeaders(LOCATION, SET_COOKIE);


### PR DESCRIPTION
## 📄 Summary
> 
- close: #452 

**같은 애플리케이션에서 보낸 요청**(Thymeleaf)이라도 HTTP 헤더의 Origin에 도메인이 명시되어 있으면, 서버는 이를 다른 출처(Origin)으로 인식합니다.
따라서 `https://api.zipgo.pet`에서 보내는 요청도 다른 출처로 인식해서 CORS 에러가 나는 것이죠. 해당 도메인을 추가해주면 간단히 해결되는 것을 확인해볼 수 있었습니다.

## 🙋🏻 More
> 즐 추 🍂 